### PR TITLE
Improve module option input and add loose mode to modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
     "babel-plugin-transform-regenerator": "^6.6.0",
-    "lodash.includes": "^4.3.0"
+    "lodash.includes": "^4.3.0",
+    "lodash.isarray": "^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@
 const babelPresetEnv = require("../lib/index.js");
 const assert = require("assert");
 
+const MODULE_TRANSFORMATIONS = babelPresetEnv.MODULE_TRANSFORMATIONS;
+
 describe("babel-preset-env", () => {
   describe("isPluginRequired", () => {
     it("returns true if no targets are specified", () => {
@@ -27,6 +29,50 @@ describe("babel-preset-env", () => {
         "edge": 12,
       };
       assert(babelPresetEnv.isPluginRequired(plugin, plugin) === true);
+    });
+  });
+  describe("getModules", () => {
+    describe("Boolean argument", () => {
+      it("should return an empty Array if passed a falsy value", () => {
+        assert.deepEqual(babelPresetEnv.getModuleTransformations(), []);
+        assert.deepEqual(babelPresetEnv.getModuleTransformations(null), []);
+        assert.deepEqual(babelPresetEnv.getModuleTransformations(false), []);
+      });
+      it("should return an Array of all module transformations if passed `true`", () => {
+        const allModuleTransformations = Object
+          .keys(MODULE_TRANSFORMATIONS)
+          .map(keys => MODULE_TRANSFORMATIONS[keys]);
+
+        assert.deepEqual(babelPresetEnv.getModuleTransformations(Object.keys(MODULE_TRANSFORMATIONS)), allModuleTransformations);
+      });
+    });
+    describe("String argument", () => {
+      it("should return an empty Array if passed an unrecognized module type", () => {
+        assert.deepEqual(babelPresetEnv.getModuleTransformations("shoelacestrap.js"), []);
+      });
+      it("should return an Array with the specified module transformation if passed a valid module string", () => {
+        const validModuleType = Object.keys(MODULE_TRANSFORMATIONS)[0];
+
+        const moduleTransformations = babelPresetEnv.getModuleTransformations(validModuleType)
+        assert.deepEqual(moduleTransformations, [MODULE_TRANSFORMATIONS[validModuleType]]);
+      });
+    });
+    describe("Array argument", () => {
+      it("should return an empty Array if passed an empty array", () => {
+        assert.deepEqual(babelPresetEnv.getModuleTransformations([]), []);
+      });
+      it("should return an Array with the module transformations if passed an Array of module types", () => {
+        const moduleTypes = Object.keys(MODULE_TRANSFORMATIONS);
+
+        const moduleTransformations = babelPresetEnv.getModuleTransformations([moduleTypes[0], moduleTypes[1]])
+        assert.deepEqual(moduleTransformations, [MODULE_TRANSFORMATIONS[moduleTypes[0]], MODULE_TRANSFORMATIONS[moduleTypes[1]]]);
+      });
+      it("should ignore invalid Array elements if passed an Array of module types", () => {
+        const moduleTypes = Object.keys(MODULE_TRANSFORMATIONS);
+
+        const moduleTransformations = babelPresetEnv.getModuleTransformations([moduleTypes[0], null, moduleTypes[1], "HenryFord.js"])
+        assert.deepEqual(moduleTransformations, [MODULE_TRANSFORMATIONS[moduleTypes[0]], MODULE_TRANSFORMATIONS[moduleTypes[1]]]);
+      });
     });
   });
 });


### PR DESCRIPTION
My goal here is to get the API fully working with the test data we have (or something very similar). Once we're all happy with how it works then it's just a matter of updating the data to tag which plugins are required in which versions + whatever bits of interdependency we have to code for.

---

This PR does the following
* Enable `loose` mode for modules. It was a one liner so I don't know why I didn't just do this before
* Finish the `opts.modules` parsing function such that it can accept a boolean, a string or an array of module types.
* Tests!

I'm pretty sure that we can call the module section feature complete after this.