### PR TITLE
Adds `browsers` property to use browserslist's queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ exports.A = A;
 export class A {}
 ```
 
+```js
+// using browserslist
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "chrome": 52,
+        "browsers": ["last 2 versions", "safari 7"]
+      }
+    }]
+  ]
+}
+
+// ...
+
+export class A {}
+```
+
 ### Example with `debug: true`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -20,19 +20,23 @@ The data for this is currently at: [/data/plugins.json](/data/plugins.json) and 
 
 Currently: "chrome, edge, firefox, safari, node"
 
-> Some node features are > `6.5`
+> Some node features are > `6.5`.
+
+*browsers* (array/string) - an query to select browsers (ex: last 2 versions, > 5%).  
+Note, browsers' results are overridden by explicit items from `targets`.
 
 * `loose` (boolean) - Enable "loose" transformations for any plugins in this preset that allow them (Disabled by default).
 * `modules` - Enable transformation of ES6 module syntax to another module type (Enabled by default to `"commonjs"`).
-  * Can be `false` to not transform modules, or one of `["amd", "umd", "systemjs", "commonjs"]`
-* `debug` (boolean) - `console.log` out the targets and plugins being used as well as the version specified in `/data/plugins.json`
+  * Can be `false` to not transform modules, or one of `["amd", "umd", "systemjs", "commonjs"]`.
+* `debug` (boolean) - `console.log` out the targets and plugins being used as well as the version specified in `/data/plugins.json`.
 
 ```js
 {
   "presets": [
     ["env", {
       "targets": {
-        "chrome": 52
+        "chrome": 52,
+        "browsers": "last 2 safari versions"
       },
       "loose": true,
       "modules": false

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Currently: "chrome, edge, firefox, safari, node"
 
 > Some node features are > `6.5`.
 
-*browsers* (array/string) - an query to select browsers (ex: last 2 versions, > 5%).  
-Note, browsers' results are overridden by explicit items from `targets`.
+* `browsers` (array/string) - an query to select browsers (ex: last 2 versions, > 5%).  
+
+> Note, browsers' results are overridden by explicit items from `targets`.
 
 * `loose` (boolean) - Enable "loose" transformations for any plugins in this preset that allow them (Disabled by default).
 * `modules` - Enable transformation of ES6 module syntax to another module type (Enabled by default to `"commonjs"`).

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
     "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
     "babel-plugin-transform-exponentiation-operator": "^6.8.0",
-    "babel-plugin-transform-regenerator": "^6.6.0"
+    "babel-plugin-transform-regenerator": "^6.6.0",
+    "browserslist": "^1.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -52,7 +53,6 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
-    "browserslist": "^1.4.0",
     "compat-table": "github:hzoo/compat-table#node-fix",
     "eslint": "^3.3.1",
     "eslint-config-babel": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
+    "browserslist": "^1.4.0",
     "compat-table": "github:hzoo/compat-table#node-fix",
     "eslint": "^3.3.1",
     "eslint-config-babel": "^1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,10 @@ export const MODULE_TRANSFORMATIONS = {
  * @return {Boolean}  Whether or not the transformation is required
  */
 export const isPluginRequired = (supportedEnvironments, plugin) => {
+  if (supportedEnvironments.browsers) {
+    supportedEnvironments = getTargets(supportedEnvironments);
+  }
+
   const targetEnvironments = Object.keys(supportedEnvironments);
 
   if (targetEnvironments.length === 0) { return true; }
@@ -62,10 +66,14 @@ export const isPluginRequired = (supportedEnvironments, plugin) => {
   return isRequiredForEnvironments.length > 0 ? true : false;
 };
 
+const isBrowsersQueryValid = browsers => {
+  return typeof browsers === 'string' || Array.isArray(browsers);
+};
+
 const getTargets = targetOpts => {
   const mergedOpts = targetOpts || {};
   const browserOpts = targetOpts['browsers'];
-  if (typeof browserOpts === 'string' || Array.isArray(browserOpts)) {
+  if (isBrowsersQueryValid(browserOpts)) {
     delete mergedOpts.browsers;
     browserslist(browserOpts).forEach(browser => {
       const [browserName, browserVer] = browser.split(' ');

--- a/src/index.js
+++ b/src/index.js
@@ -89,15 +89,12 @@ const mergeBrowsers = (fromQuery, fromTarget) => {
 };
 
 const getTargets = targetOpts => {
-  let mergedOpts;
   const browserOpts = targetOpts.browsers;
   if (isBrowsersQueryValid(browserOpts)) {
     const queryBrowsers = getLowestVersions(browserslist(browserOpts));
-    mergedOpts = mergeBrowsers(queryBrowsers, targetOpts);
-  } else {
-    mergedOpts = targetOpts;
+    return mergeBrowsers(queryBrowsers, targetOpts);
   }
-  return mergedOpts;
+  return targetOpts;
 };
 
 // TODO: Allow specifying plugins as either shortened or full name

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,6 @@ const isBrowsersQueryValid = browsers => {
 const getLowestVersions = (browsers) => {
   return browsers.reduce((all, browser) => {
     const [browserName, browserVersion] = browser.split(' ');
-    const previousBrowserVersion = all[browserName];
     all[browserName] = parseInt(browserVersion);
     return all;
   }, {});

--- a/src/index.js
+++ b/src/index.js
@@ -67,12 +67,12 @@ export const isPluginRequired = (supportedEnvironments, plugin) => {
 };
 
 const isBrowsersQueryValid = browsers => {
-  return typeof browsers === 'string' || Array.isArray(browsers);
+  return typeof browsers === "string" || Array.isArray(browsers);
 };
 
 const getLowestVersions = (browsers) => {
   return browsers.reduce((all, browser) => {
-    const [browserName, browserVersion] = browser.split(' ');
+    const [browserName, browserVersion] = browser.split(" ");
     all[browserName] = parseInt(browserVersion);
     return all;
   }, {});
@@ -80,7 +80,7 @@ const getLowestVersions = (browsers) => {
 
 const mergeBrowsers = (fromQuery, fromTarget) => {
   return Object.keys(fromTarget).reduce((queryObj, targKey) => {
-    if (targKey !== 'browsers') {
+    if (targKey !== "browsers") {
       queryObj[targKey] = fromTarget[targKey];
     }
     return queryObj;

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ const getTargets = targetOpts => {
     delete mergedOpts.browsers;
     browserslist(browserOpts).forEach(browser => {
       const [browserName, browserVer] = browser.split(' ');
-      if (!mergedOpts[browserName]) mergedOpts[browserName] = browserVer;
+      if (!mergedOpts[browserName]) mergedOpts[browserName] = parseInt(browserVer);
     });
   }
   return mergedOpts;

--- a/src/index.js
+++ b/src/index.js
@@ -70,15 +70,32 @@ const isBrowsersQueryValid = browsers => {
   return typeof browsers === 'string' || Array.isArray(browsers);
 };
 
+const getLowestVersions = (browsers) => {
+  return browsers.reduce((all, browser) => {
+    const [browserName, browserVersion] = browser.split(' ');
+    const previousBrowserVersion = all[browserName];
+    all[browserName] = parseInt(browserVersion);
+    return all;
+  }, {});
+};
+
+const mergeBrowsers = (fromQuery, fromTarget) => {
+  return Object.keys(fromTarget).reduce((queryObj, targKey) => {
+    if (targKey !== 'browsers') {
+      queryObj[targKey] = fromTarget[targKey];
+    }
+    return queryObj;
+  }, fromQuery);
+};
+
 const getTargets = targetOpts => {
-  const mergedOpts = targetOpts || {};
-  const browserOpts = targetOpts['browsers'];
+  let mergedOpts;
+  const browserOpts = targetOpts.browsers;
   if (isBrowsersQueryValid(browserOpts)) {
-    delete mergedOpts.browsers;
-    browserslist(browserOpts).forEach(browser => {
-      const [browserName, browserVer] = browser.split(' ');
-      if (!mergedOpts[browserName]) mergedOpts[browserName] = parseInt(browserVer);
-    });
+    const queryBrowsers = getLowestVersions(browserslist(browserOpts));
+    mergedOpts = mergeBrowsers(queryBrowsers, targetOpts);
+  } else {
+    mergedOpts = targetOpts;
   }
   return mergedOpts;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
 // "es5-property-mutators",
 
 import pluginList from "../data/plugins.json";
+import browserslist from "browserslist";
 
 export const plugins = [
   "es3-member-expression-literals",
@@ -62,7 +63,16 @@ export const isPluginRequired = (supportedEnvironments, plugin) => {
 };
 
 const getTargets = targetOpts => {
-  return targetOpts || {};
+  const mergedOpts = targetOpts || {};
+  const browserOpts = targetOpts['browsers'];
+  if (typeof browserOpts === 'string' || Array.isArray(browserOpts)) {
+    delete mergedOpts.browsers;
+    browserslist(browserOpts).forEach(browser => {
+      const [browserName, browserVer] = browser.split(' ');
+      if (!mergedOpts[browserName]) mergedOpts[browserName] = browserVer;
+    });
+  }
+  return mergedOpts;
 };
 
 // TODO: Allow specifying plugins as either shortened or full name

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,38 @@ describe("babel-preset-env", () => {
       assert(babelPresetEnv.isPluginRequired(targets, plugin) === true);
     });
 
+    it("returns false if plugin feature is implemented by lower than target defined in browsers query", () => {
+      const plugin = {
+        chrome: 49,
+      };
+      const targets = {
+        "browsers": "chrome > 50"
+      };
+      assert(babelPresetEnv.isPluginRequired(targets, plugin) === false);
+    });
+
+    it("returns true if plugin feature is implemented is greater than target defined in browsers query", () => {
+      const plugin = {
+        chrome: 52,
+      };
+      const targets = {
+        "browsers": "chrome > 50"
+      };
+      assert(babelPresetEnv.isPluginRequired(targets, plugin) === true);
+    });
+
+    it("returns true if target's root items overrides versions defined in browsers query", () => {
+      const plugin = {
+        chrome: 45,
+      };
+      const targets = {
+        browsers: "last 2 Chrome versions",
+        chrome: 44
+      };
+
+      assert(babelPresetEnv.isPluginRequired(targets, plugin) === true);
+    });
+
     it("doesn't throw when specifiying a decimal for node", () => {
       let targets;
       const plugin = {


### PR DESCRIPTION
This PR allows us to use **browsers** property with query like autoprefixer does.

For example, **babelrc**:

```js
{
  presets: [
    ["env", {
      "targets": {
        "chrome": 52,
        "browsers": ["safari > 7"]
      },
      "loose": true
    }]
  ]
}
```
will include chrome 52 and safari 8, 9, 10.

ios_saf, ie11 and others unsupported browsers will be ignored.
