### PR TITLE
If babel doesn't implement it either, don't count against it

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -1,10 +1,10 @@
 {
   "transform-es2015-arrow-functions": {
-    "chrome": 47,
+    "chrome": 45,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
-    "node": 6,
+    "node": 4,
     "ios": 10
   },
   "transform-es2015-block-scoped-functions": {
@@ -23,11 +23,11 @@
     "ios": 10
   },
   "transform-es2015-classes": {
-    "chrome": 46,
+    "chrome": 45,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
-    "node": 5,
+    "node": 4,
     "ios": 10
   },
   "transform-es2015-computed-properties": {
@@ -66,21 +66,23 @@
   "transform-es2015-literals": {
     "chrome": 44,
     "edge": 12,
+    "firefox": 40,
     "safari": 9,
     "node": 4,
     "ios": 9
   },
   "transform-es2015-object-super": {
-    "chrome": 46,
+    "chrome": 41,
     "edge": 13,
     "firefox": 45,
-    "safari": 10,
-    "node": 5,
-    "ios": 10
+    "safari": 9,
+    "node": 4,
+    "ios": 9
   },
   "transform-es2015-parameters": {
     "chrome": 49,
     "edge": 14,
+    "firefox": 43,
     "safari": 10,
     "node": 6,
     "ios": 10
@@ -102,16 +104,19 @@
     "ios": 10
   },
   "transform-es2015-sticky-regex": {
-    "chrome": 49,
-    "edge": 13,
-    "firefox": 3,
-    "safari": 10,
-    "node": 6,
-    "ios": 10
+    "chrome": -1,
+    "edge": -1,
+    "firefox": -1,
+    "safari": -1,
+    "node": -1,
+    "ie": -1,
+    "android": -1,
+    "ios": -1,
+    "phantom": -1
   },
   "transform-es2015-template-literals": {
     "chrome": 41,
-    "edge": 13,
+    "edge": 12,
     "firefox": 34,
     "safari": 9,
     "node": 4,

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -82,6 +82,13 @@ const getLowestImplementedVersion = ({ features }, env) => {
 
   let envTests = tests
   .map(({ res: test, name }, i) => {
+    // Babel itself doesn't implement the feature correctly,
+    // don't count against it
+    if (!test.babel) {
+      // console.log(name);
+      return "-1";
+    }
+
     // `equals` in compat-table
     Object.keys(test).forEach((t) => {
       test[invertedEqualsEnv[t]] = test[t];


### PR DESCRIPTION
Didn't get to this at the time and the fix is actually pretty simple I think?

@jdalton mentioned in https://github.com/babel/babel-preset-env/commit/b80dfaaa7f88cd569b037bd54fc1712329af13d1#commitcomment-19652847 that node 4 supports arrow-functions. It's a similar thing for other transforms which I noticed before but didn't look into. This seems to change a bunch to node 4.

<details>
<summary> the entries babel is failing at (or w/ non-spec option)</summary>
arrow functions/correct precedence

arrow functions/no "prototype" property
arrow functions/lexical "super" binding in constructors
arrow functions/lexical "new.target" binding
class/computed names, temporal dead zone
class/extends null
class/new.target
super/statement in constructors
super/expression in constructors
super/constructor calls use correct "new.target" binding
super/super() invokes the correct constructor
destructuring, parameters/new Function() support
destructuring, parameters/defaults, separate scope
destructuring, parameters/defaults, new Function() support
function "name" property/new Function
function "name" property/bound functions
function "name" property/accessor properties
function "name" property/symbol-keyed methods
function "name" property/object methods (class)
function "name" property/isn't writable, is configurable
Unicode code point escapes/in identifiers
default function parameters/temporal dead zone
default function parameters/separate scope
default function parameters/new Function() support
rest parameters/can't be used in setters
rest parameters/new Function() support
spread (...) operator/with sparse arrays, in array literals
spread (...) operator/spreading non-iterables is a runtime error
RegExp "y" and "u" flags / "y" flag
RegExp "y" and "u" flags / "y" flag, lastIndex
template literals/toString conversion
generators/can't use "this" with new
generators/%GeneratorPrototype%.constructor
generators/yield * on non-iterables is a runtime error
<details>