### PR TITLE
hardcode a current node version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Currently: "chrome, edge, firefox, safari, ie, node".
 
 > Note, browsers' results are overridden by explicit items from `targets`.
 
-> If your config is a js file, also do `"node": parseFloat(process.versions.node)`
+If you want to compile against the current node version, you can specify `"node": true` or `"node": "current"` which would be the same as `node": parseFloat(process.versions.node)`
 
 * `loose` (boolean) - Enable "loose" transformations for any plugins in this preset that allow them (Defaults to `false`).
 * `modules` - Enable transformation of ES6 module syntax to another module type (Defaults to `"commonjs"`).
@@ -64,7 +64,7 @@ Currently: "chrome, edge, firefox, safari, ie, node".
 * `whitelist` (Array<string>) - Enable a whitelist of plugins to always include. (Defaults to `[]`)
   * Useful if there is a bug in a native implementation, or a combination of a non-supported feature + a supported one doesn't work. (Ex: Node 4 supports native classes but not spread) 
 
-### Example
+### Examples
 
 ```js
 // src
@@ -141,6 +141,26 @@ export var A = function A() {
 };
 ```
 
+#### Example with `node: true` or `node: "current"`
+
+```js
+// process.versions.node -> 6.9.0
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "current"
+      }
+    }]
+  ]
+}
+
+// ...
+
+class A {}
+exports.A = A;
+```
+
 ### Example with `debug: true`
 
 ```js
@@ -178,7 +198,6 @@ transform-async-to-generator {}
 syntax-trailing-function-commas {}
 transform-es2015-arrow-functions {}
 ```
-
 
 ## Caveats
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,15 @@ const mergeBrowsers = (fromQuery, fromTarget) => {
   }, fromQuery);
 };
 
-const getTargets = (targetOpts = {}) => {
+export const getCurrentNodeVersion = () => {
+  return parseFloat(process.versions.node);
+};
+
+export const getTargets = (targetOpts = {}) => {
+  if (targetOpts.node === true || targetOpts.node === "current") {
+    targetOpts.node = getCurrentNodeVersion();
+  }
+
   const browserOpts = targetOpts.browsers;
   if (isBrowsersQueryValid(browserOpts)) {
     const queryBrowsers = getLowestVersions(browserslist(browserOpts));

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,22 @@ const {
 } = babelPresetEnv;
 
 describe("babel-preset-env", () => {
+  describe("getTargets", () => {
+    it("should return the current node version with option 'current'", function() {
+      assert.deepEqual(babelPresetEnv.getTargets({
+        node: true
+      }), {
+        node: parseFloat(process.versions.node)
+      });
+
+      assert.deepEqual(babelPresetEnv.getTargets({
+        node: "current"
+      }), {
+        node: parseFloat(process.versions.node)
+      });
+    });
+  });
+
   describe("isPluginRequired", () => {
     it("returns true if no targets are specified", () => {
       const isRequired = babelPresetEnv.isPluginRequired({}, {});


### PR DESCRIPTION
For https://github.com/babel/babel-preset-env/issues/9

If a user wants to compile babel against the current node version (`node --version`) but doesn't want to use js for the config (in package.json/.babelrc rather than say babel-loader or a separate file)

`node: "--version"` -> `"node": parseFloat(process.versions.node)`?

![screen shot 2016-11-02 at 2 43 36 pm](https://cloud.githubusercontent.com/assets/588473/19942638/ca9c76de-a10a-11e6-8f93-08e316045224.png)

Option name ideas?

- true
- "version"
- "current version"
- "process"
- "--version"

cc @shubheksha