### PR TITLE
Use compat-table equals option

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -4,122 +4,141 @@
     "edge": 13,
     "firefox": 45,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-es2015-block-scoped-functions": {
     "chrome": 41,
     "firefox": 46,
     "safari": 10,
     "node": 4,
-    "ie": 11
+    "ie": 11,
+    "ios": 10
   },
   "transform-es2015-block-scoping": {
     "chrome": 49,
     "firefox": 51,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-es2015-classes": {
     "chrome": 46,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
-    "node": 5
+    "node": 5,
+    "ios": 10
   },
   "transform-es2015-computed-properties": {
     "chrome": 44,
     "edge": 12,
     "firefox": 34,
     "safari": 7,
-    "node": 4
+    "node": 4,
+    "ios": 8
   },
   "check-es2015-constants": {
     "chrome": 49,
     "firefox": 51,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-es2015-destructuring": {
     "chrome": 51,
     "safari": 10,
-    "node": 6.5
+    "node": 6.5,
+    "ios": 10
   },
   "transform-es2015-for-of": {
     "chrome": 51,
     "safari": 10,
-    "node": 6.5
+    "node": 6.5,
+    "ios": 10
   },
   "transform-es2015-function-name": {
     "chrome": 51,
     "safari": 10,
-    "node": 6.5
+    "node": 6.5,
+    "ios": 10
   },
   "transform-es2015-literals": {
     "chrome": 44,
     "edge": 12,
     "safari": 9,
-    "node": 4
+    "node": 4,
+    "ios": 9
   },
   "transform-es2015-object-super": {
     "chrome": 46,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
-    "node": 5
+    "node": 5,
+    "ios": 10
   },
   "transform-es2015-parameters": {
     "chrome": 49,
     "edge": 14,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-es2015-shorthand-properties": {
     "chrome": 43,
     "edge": 12,
     "firefox": 33,
     "safari": 9,
-    "node": 4
+    "node": 4,
+    "ios": 9
   },
   "transform-es2015-spread": {
     "chrome": 46,
     "edge": 13,
     "firefox": 36,
     "safari": 10,
-    "node": 5
+    "node": 5,
+    "ios": 10
   },
   "transform-es2015-sticky-regex": {
     "chrome": 49,
     "edge": 13,
     "firefox": 3,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-es2015-template-literals": {
     "chrome": 41,
     "edge": 13,
     "firefox": 34,
     "safari": 9,
-    "node": 4
+    "node": 4,
+    "ios": 9
   },
   "transform-es2015-typeof-symbol": {
     "chrome": 38,
     "edge": 12,
     "firefox": 36,
     "safari": 9,
-    "node": 0.12
+    "node": 0.12,
+    "ios": 9
   },
   "transform-es2015-unicode-regex": {
     "chrome": 50,
     "edge": 13,
     "firefox": 46,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-regenerator": {
     "chrome": 50,
     "edge": 13,
     "safari": 10,
-    "node": 6
+    "node": 6,
+    "ios": 10
   },
   "transform-exponentiation-operator": {
     "chrome": 52,
@@ -133,6 +152,7 @@
   "syntax-trailing-function-commas": {
     "edge": 14,
     "firefox": 52,
-    "safari": 10
+    "safari": 10,
+    "ios": 10
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flow-vars": "^0.5.0",
     "lodash": "^4.15.0",
-    "mocha": "^3.0.2",
-    "natural-compare": "^1.4.0"
+    "mocha": "^3.0.2"
   },
   "babel": {
     "presets": [

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -12,10 +12,12 @@ const es6Data = require("compat-table/data-es6");
 es6Data.browsers.node6 = es6Data.browsers["node64"];
 const es6PlusData = require("compat-table/data-es2016plus");
 
-let invertedEqualsEnv = {};
-Object.keys(es6Data.browsers)
+const invertedEqualsEnv = Object.keys(es6Data.browsers)
   .filter((b) => es6Data.browsers[b].equals)
-  .forEach((b) => invertedEqualsEnv[es6Data.browsers[b].equals] = b);
+  .reduce((a, b) => {
+    a[es6Data.browsers[b].equals] = b;
+    return a;
+  }, {});
 
 const compatibilityTests = flattenDeep([
   es6Data,

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -3,15 +3,23 @@ const path = require("path");
 
 const flatten = require("lodash/flatten");
 const flattenDeep = require("lodash/flattenDeep");
-// const naturalCompare = require("natural-compare");
 const pluginFeatures = require("../data/pluginFeatures");
 
 const renameTests = (tests, getName) =>
   tests.map((test) => Object.assign({}, test, { name: getName(test.name) }));
 
+const es6Data = require("compat-table/data-es6");
+es6Data.browsers.node6 = es6Data.browsers["node64"];
+const es6PlusData = require("compat-table/data-es2016plus");
+
+let invertedEqualsEnv = {};
+Object.keys(es6Data.browsers)
+  .filter((b) => es6Data.browsers[b].equals)
+  .forEach((b) => invertedEqualsEnv[es6Data.browsers[b].equals] = b);
+
 const compatibilityTests = flattenDeep([
-  require("compat-table/data-es6"),
-  require("compat-table/data-es2016plus"),
+  es6Data,
+  es6PlusData,
 ].map((data) =>
   data.tests.map((test) => {
     return test.subtests ?
@@ -19,8 +27,6 @@ const compatibilityTests = flattenDeep([
       test;
   })
 ));
-
-// const versions = Object.keys(require("compat-table/data-es6").browsers).sort(naturalCompare);
 
 const environments = [
   "chrome",
@@ -30,7 +36,8 @@ const environments = [
   "node",
   "ie",
   "android",
-  "ios"
+  "ios",
+  "phantom"
 ];
 
 const envMap = {
@@ -72,6 +79,11 @@ const getLowestImplementedVersion = ({ features }, env) => {
 
   let envTests = tests
   .map(({ res: test, name }, i) => {
+    // `equals` in compat-table
+    Object.keys(test).forEach((t) => {
+      test[invertedEqualsEnv[t]] = test[t];
+    });
+
     return Object.keys(test)
     .filter((t) => t.startsWith(env))
     // Babel assumes strict mode


### PR DESCRIPTION
Ref https://github.com/babel/babel-preset-env/issues/25

```js
// invertedEqualsEnv
{
  "safari6": "phantom",
  "chrome44": "iojs",
  "chrome50": "node64",
  "chrome51": "node65",
  "chrome54": "node7",
  "chrome30": "android44",
  "chrome37": "android50",
  "chrome39": "android51",
  "safari7": "ios7",
  "safari71_8": "ios8",
  "safari9": "ios9",
  "safari10": "ios10",
  "chrome50": "node6"
}
```