### PR TITLE
Rename ios_saf in browserslist data to ios, ignore unknown browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,13 +48,13 @@ const isBrowsersQueryValid = (browsers) => {
 };
 
 const browserNameMap = {
-  chrome: 'chrome',
-  edge: 'edge',
-  firefox: 'firefox',
-  ie: 'ie',
-  ios_saf: 'ios',
-  safari: 'safari'
-}
+  chrome: "chrome",
+  edge: "edge",
+  firefox: "firefox",
+  ie: "ie",
+  ios_saf: "ios",
+  safari: "safari"
+};
 
 const getLowestVersions = (browsers) => {
   return browsers.reduce((all, browser) => {

--- a/src/index.js
+++ b/src/index.js
@@ -47,10 +47,21 @@ const isBrowsersQueryValid = (browsers) => {
   return typeof browsers === "string" || Array.isArray(browsers);
 };
 
+const browserNameMap = {
+  chrome: 'chrome',
+  edge: 'edge',
+  firefox: 'firefox',
+  ie: 'ie',
+  ios_saf: 'ios',
+  safari: 'safari'
+}
+
 const getLowestVersions = (browsers) => {
   return browsers.reduce((all, browser) => {
     const [browserName, browserVersion] = browser.split(" ");
-    all[browserName] = parseInt(browserVersion);
+    if (browserName in browserNameMap) {
+      all[browserNameMap[browserName]] = parseInt(browserVersion);
+    }
     return all;
   }, {});
 };


### PR DESCRIPTION
browserslist queries, especially ones with percentages, often bring in mobile browsers that _probably_ have the similar support level as desktop ones, but since there's no support for them in the data, including them here would just lead to all plugins being enabled always.

It's also easy to get crazy things like `operamini` or `and_uc` in the results even if you don't actually want to support them.

Browserslist also reports iOS Safari as `ios_saf`, while the data uses `ios`, so it needs to be renamed.