### PR TITLE
Only console.log the debug info once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,8 @@ export const validateWhitelistOption = (whitelistOpt = []) => {
   return whitelistOpt;
 };
 
+let alreadyLogged = false;
+
 export default function buildPreset(context, opts = {}) {
   const loose = validateLooseOption(opts.loose);
   const moduleType = validateModulesOption(opts.modules);
@@ -142,7 +144,10 @@ export default function buildPreset(context, opts = {}) {
   let transformations = Object.keys(pluginList)
     .filter((pluginName) => isPluginRequired(targets, pluginList[pluginName]));
 
-  if (debug) {
+  if (debug && !alreadyLogged) {
+    alreadyLogged = true;
+
+    console.log("babel-preset-env: `DEBUG` option");
     console.log("");
     console.log(`Using targets: ${JSON.stringify(targets, null, 2)}`);
     console.log("");

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ export const validateWhitelistOption = (whitelistOpt = []) => {
   return whitelistOpt;
 };
 
-let alreadyLogged = false;
+let hasBeenLogged = false;
 
 export default function buildPreset(context, opts = {}) {
   const loose = validateLooseOption(opts.loose);
@@ -144,8 +144,8 @@ export default function buildPreset(context, opts = {}) {
   let transformations = Object.keys(pluginList)
     .filter((pluginName) => isPluginRequired(targets, pluginList[pluginName]));
 
-  if (debug && !alreadyLogged) {
-    alreadyLogged = true;
+  if (debug && !hasBeenLogged) {
+    hasBeenLogged = true;
 
     console.log("babel-preset-env: `DEBUG` option");
     console.log("");


### PR DESCRIPTION
Saw that when I was running the debug option it would be logging many times which isn't necessary.