### PR TITLE
Update data generation for latest compat-table

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -19,6 +19,7 @@
   },
   "transform-es2015-block-scoping": {
     "chrome": 49,
+    "opera": 36,
     "firefox": 51,
     "safari": 10,
     "node": 6,
@@ -39,11 +40,11 @@
     "edge": 12,
     "firefox": 34,
     "safari": 7,
-    "node": 4,
-    "ios": 8
+    "node": 4
   },
   "check-es2015-constants": {
     "chrome": 49,
+    "opera": 36,
     "firefox": 51,
     "safari": 10,
     "node": 6,
@@ -53,18 +54,17 @@
     "chrome": 51,
     "opera": 38,
     "safari": 10,
-    "node": 6.5,
-    "ios": 10
+    "node": 6.5
   },
   "transform-es2015-for-of": {
     "chrome": 51,
     "opera": 38,
     "safari": 10,
-    "node": 6.5,
-    "ios": 10
+    "node": 6.5
   },
   "transform-es2015-function-name": {
     "chrome": 51,
+    "opera": 38,
     "safari": 10,
     "node": 6.5,
     "ios": 10
@@ -109,8 +109,7 @@
     "edge": 13,
     "firefox": 36,
     "safari": 10,
-    "node": 5,
-    "ios": 10
+    "node": 5
   },
   "transform-es2015-sticky-regex": {
     "chrome": 49,

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -40,7 +40,8 @@
     "edge": 12,
     "firefox": 34,
     "safari": 7,
-    "node": 4
+    "node": 4,
+    "ios": 10
   },
   "check-es2015-constants": {
     "chrome": 49,
@@ -54,13 +55,15 @@
     "chrome": 51,
     "opera": 38,
     "safari": 10,
-    "node": 6.5
+    "node": 6.5,
+    "ios": 10
   },
   "transform-es2015-for-of": {
     "chrome": 51,
     "opera": 38,
     "safari": 10,
-    "node": 6.5
+    "node": 6.5,
+    "ios": 10
   },
   "transform-es2015-function-name": {
     "chrome": 51,
@@ -109,7 +112,8 @@
     "edge": 13,
     "firefox": 36,
     "safari": 10,
-    "node": 5
+    "node": 5,
+    "ios": 10
   },
   "transform-es2015-sticky-regex": {
     "chrome": 49,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
-    "compat-table": "github:kangax/compat-table#gh-pages",
+    "compat-table": "github:kangax/compat-table#e732718eab42c6c83a364450f456474638d31f94",
     "eslint": "^3.3.1",
     "eslint-config-babel": "^1.0.1",
     "eslint-plugin-babel": "^3.3.0",

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -11,7 +11,6 @@ const renameTests = (tests, getName) =>
 const es6Data = require("compat-table/data-es6");
 const es6PlusData = require("compat-table/data-es2016plus");
 const envs = require("compat-table/environments");
-envs.node6 = envs.node64;
 
 const invertedEqualsEnv = Object.keys(envs)
   .filter((b) => envs[b].equals)
@@ -47,11 +46,9 @@ const environments = [
 const envMap = {
   safari51: "safari5",
   safari71_8: "safari7",
-  chrome: "chrome19",
-  chrome19dev: "chrome19",
-  chrome21dev: "chrome21",
   firefox3_5: "firefox3",
   firefox3_6: "firefox3",
+  node010: "node0.10",
   node012: "node0.12",
   iojs: "node3.3",
   node64: "node6",
@@ -62,7 +59,8 @@ const envMap = {
   android43: "android4.3",
   android44: "android4.4",
   android50: "android5.0",
-  android51: "android5.1"
+  android51: "android5.1",
+  ios51: "ios5.1",
 };
 
 const getLowestImplementedVersion = ({ features }, env) => {


### PR DESCRIPTION
See https://github.com/kangax/compat-table/pull/964

Still need to realise why ios 8 was removed from new generated data