### PR TITLE
add support for engines with flags Fixes #41

### DIFF
--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -7,7 +7,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.int8-array": {
     "chrome": 5,
@@ -17,7 +19,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.uint8-array": {
     "chrome": 5,
@@ -27,7 +31,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.uint8-clamped-array": {
     "chrome": 5,
@@ -36,7 +42,10 @@
     "firefox": 4,
     "safari": 6,
     "node": 0.12,
-    "ios": 7
+    "ios": 7,
+    "chrome-flag": 5,
+    "edge-flag": 12,
+    "node-flag": 0.12
   },
   "es6.typed.int16-array": {
     "chrome": 5,
@@ -46,7 +55,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.uint16-array": {
     "chrome": 5,
@@ -56,7 +67,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.int32-array": {
     "chrome": 5,
@@ -66,7 +79,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.uint32-array": {
     "chrome": 5,
@@ -76,7 +91,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.float32-array": {
     "chrome": 5,
@@ -86,7 +103,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.typed.float64-array": {
     "chrome": 5,
@@ -96,7 +115,9 @@
     "node": 0.12,
     "ie": 10,
     "android": 4.1,
-    "ios": 6
+    "ios": 6,
+    "chrome-flag": 5,
+    "node-flag": 0.12
   },
   "es6.map": {
     "chrome": 51,
@@ -104,6 +125,8 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": null,
+    "node-flag": 6.5,
     "opera": 38
   },
   "es6.set": {
@@ -112,6 +135,8 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": null,
+    "node-flag": 6.5,
     "opera": 38
   },
   "es6.weak-map": {
@@ -119,6 +144,7 @@
     "firefox": 53,
     "safari": 9,
     "ios": 9,
+    "chrome-flag": null,
     "opera": 38
   },
   "es6.weak-set": {
@@ -127,6 +153,8 @@
     "firefox": 53,
     "safari": 9,
     "ios": 9,
+    "chrome-flag": 51,
+    "edge-flag": 15,
     "opera": 38
   },
   "es6.reflect.apply": {
@@ -135,6 +163,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.construct": {
@@ -143,6 +173,8 @@
     "firefox": 45,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 13,
     "opera": 36
   },
   "es6.reflect.define-property": {
@@ -151,6 +183,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 13,
     "opera": 36
   },
   "es6.reflect.delete-property": {
@@ -159,6 +193,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.get": {
@@ -167,6 +203,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.get-own-property-descriptor": {
@@ -175,6 +213,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.get-prototype-of": {
@@ -183,6 +223,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.has": {
@@ -191,6 +233,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.is-extensible": {
@@ -199,6 +243,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.own-keys": {
@@ -207,6 +253,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.prevent-extensions": {
@@ -215,6 +263,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.set": {
@@ -223,6 +273,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.reflect.set-prototype-of": {
@@ -231,6 +283,8 @@
     "firefox": 42,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 12,
     "opera": 36
   },
   "es6.promise": {
@@ -240,6 +294,9 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 13,
+    "node-flag": 6,
     "opera": 38
   },
   "es6.symbol": {
@@ -247,6 +304,7 @@
     "firefox": 51,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 50,
     "opera": 38
   },
   "es6.object.assign": {
@@ -256,6 +314,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 45,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 32
   },
   "es6.object.is": {
@@ -265,7 +326,10 @@
     "safari": 9,
     "node": 0.12,
     "android": 4.1,
-    "ios": 9
+    "ios": 9,
+    "chrome-flag": 19,
+    "edge-flag": 12,
+    "node-flag": 0.12
   },
   "es6.object.set-prototype-of": {
     "chrome": 34,
@@ -274,6 +338,8 @@
     "node": 0.12,
     "ie": 11,
     "ios": 9,
+    "chrome-flag": 34,
+    "node-flag": 0.12,
     "opera": 21
   },
   "es6.function.name": {
@@ -282,6 +348,9 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 12,
+    "node-flag": 6.5,
     "opera": 38
   },
   "es6.string.raw": {
@@ -291,6 +360,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 41,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 28
   },
   "es6.string.from-code-point": {
@@ -300,6 +372,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 38,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 28
   },
   "es6.string.code-point-at": {
@@ -309,6 +384,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 38,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 28
   },
   "es6.string.repeat": {
@@ -318,6 +396,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 30,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 28
   },
   "es6.string.starts-with": {
@@ -327,6 +408,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 28
   },
   "es6.string.ends-with": {
@@ -336,6 +420,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 28
   },
   "es6.string.includes": {
@@ -345,6 +432,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 41,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 28
   },
   "es6.regexp.flags": {
@@ -352,6 +442,8 @@
     "firefox": 37,
     "safari": 9,
     "ios": 9,
+    "chrome-flag": 48,
+    "edge-flag": 14,
     "opera": 36
   },
   "es6.regexp.match": {
@@ -360,6 +452,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 14,
+    "node-flag": 6,
     "opera": 37
   },
   "es6.regexp.replace": {
@@ -368,6 +463,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 14,
+    "node-flag": 6,
     "opera": 37
   },
   "es6.regexp.split": {
@@ -376,6 +474,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 14,
+    "node-flag": 6,
     "opera": 37
   },
   "es6.regexp.search": {
@@ -384,6 +485,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 14,
+    "node-flag": 6,
     "opera": 37
   },
   "es6.array.from": {
@@ -393,6 +497,9 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": 51,
+    "edge-flag": 15,
+    "node-flag": 6.5,
     "opera": 38
   },
   "es6.array.of": {
@@ -402,6 +509,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 39,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 32
   },
   "es6.array.copy-within": {
@@ -411,6 +521,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 45,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 32
   },
   "es6.array.find": {
@@ -420,6 +533,9 @@
     "safari": 8,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 30,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 32
   },
   "es6.array.find-index": {
@@ -429,6 +545,9 @@
     "safari": 8,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 30,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 32
   },
   "es6.array.fill": {
@@ -438,6 +557,9 @@
     "safari": 8,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 36,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 32
   },
   "es6.array.iterator": {
@@ -447,6 +569,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 30,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.number.is-finite": {
@@ -456,7 +581,10 @@
     "safari": 9,
     "node": 0.12,
     "android": 4.1,
-    "ios": 9
+    "ios": 9,
+    "chrome-flag": 19,
+    "edge-flag": 12,
+    "node-flag": 0.12
   },
   "es6.number.is-integer": {
     "chrome": 34,
@@ -465,6 +593,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 21
   },
   "es6.number.is-safe-integer": {
@@ -474,6 +605,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 21
   },
   "es6.number.is-nan": {
@@ -483,7 +617,10 @@
     "safari": 9,
     "node": 0.12,
     "android": 4.1,
-    "ios": 9
+    "ios": 9,
+    "chrome-flag": 19,
+    "edge-flag": 12,
+    "node-flag": 0.12
   },
   "es6.number.epsilon": {
     "chrome": 34,
@@ -492,6 +629,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 21
   },
   "es6.number.min-safe-integer": {
@@ -501,6 +641,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 21
   },
   "es6.number.max-safe-integer": {
@@ -510,6 +653,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 21
   },
   "es6.math.acosh": {
@@ -519,6 +665,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.asinh": {
@@ -528,6 +677,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.atanh": {
@@ -537,6 +689,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.cbrt": {
@@ -546,6 +701,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.clz32": {
@@ -555,6 +713,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 35,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.cosh": {
@@ -564,6 +725,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.expm1": {
@@ -573,6 +737,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 35,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.fround": {
@@ -582,6 +749,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 35,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.hypot": {
@@ -591,6 +761,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.imul": {
@@ -601,6 +774,9 @@
     "node": 0.12,
     "android": 4.4,
     "ios": 7,
+    "chrome-flag": 30,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 17
   },
   "es6.math.log1p": {
@@ -610,6 +786,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 35,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.log10": {
@@ -619,6 +798,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.log2": {
@@ -628,6 +810,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.sign": {
@@ -637,6 +822,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 33,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.sinh": {
@@ -646,6 +834,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.tanh": {
@@ -655,6 +846,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 34,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es6.math.trunc": {
@@ -664,6 +858,9 @@
     "safari": 8,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 33,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "es7.array.includes": {
@@ -672,6 +869,8 @@
     "firefox": 43,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 47,
+    "edge-flag": 14,
     "opera": 34
   },
   "es7.object.values": {
@@ -679,6 +878,9 @@
     "edge": 14,
     "firefox": 47,
     "node": 7,
+    "chrome-flag": 51,
+    "edge-flag": 14,
+    "node-flag": 6.5,
     "opera": 41
   },
   "es7.object.entries": {
@@ -686,6 +888,9 @@
     "edge": 14,
     "firefox": 47,
     "node": 7,
+    "chrome-flag": 51,
+    "edge-flag": 14,
+    "node-flag": 6.5,
     "opera": 41
   },
   "es7.object.get-own-property-descriptors": {
@@ -693,6 +898,9 @@
     "edge": 15,
     "firefox": 50,
     "node": 7,
+    "chrome-flag": 54,
+    "edge-flag": 15,
+    "node-flag": 7,
     "opera": 41
   },
   "es7.string.pad-start": {
@@ -701,6 +909,8 @@
     "firefox": 48,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 52,
+    "edge-flag": 14,
     "opera": 44
   },
   "es7.string.pad-end": {
@@ -709,6 +919,8 @@
     "firefox": 48,
     "safari": 10,
     "ios": 10,
+    "chrome-flag": 52,
+    "edge-flag": 14,
     "opera": 44
   }
 }

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -6,6 +6,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 47,
+    "edge-flag": 13,
+    "node-flag": 6,
     "opera": 34
   },
   "transform-es2015-block-scoped-functions": {
@@ -15,6 +18,8 @@
     "node": 4,
     "ie": 11,
     "ios": 10,
+    "chrome-flag": null,
+    "node-flag": 0.12,
     "opera": 28
   },
   "transform-es2015-block-scoping": {
@@ -23,6 +28,8 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 48,
+    "node-flag": 6,
     "opera": 36
   },
   "transform-es2015-classes": {
@@ -32,6 +39,9 @@
     "safari": 10,
     "node": 5,
     "ios": 10,
+    "chrome-flag": 46,
+    "edge-flag": 13,
+    "node-flag": 5,
     "opera": 33
   },
   "transform-es2015-computed-properties": {
@@ -41,6 +51,9 @@
     "safari": 8,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 44,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 31
   },
   "check-es2015-constants": {
@@ -49,6 +62,8 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 48,
+    "node-flag": 6,
     "opera": 36
   },
   "transform-es2015-destructuring": {
@@ -57,6 +72,9 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": 51,
+    "edge-flag": 15,
+    "node-flag": 6.5,
     "opera": 38
   },
   "transform-es2015-for-of": {
@@ -65,6 +83,9 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": 51,
+    "edge-flag": 15,
+    "node-flag": 6.5,
     "opera": 38
   },
   "transform-es2015-function-name": {
@@ -73,6 +94,9 @@
     "safari": 10,
     "node": 6.5,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 12,
+    "node-flag": 6.5,
     "opera": 38
   },
   "transform-es2015-literals": {
@@ -82,6 +106,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 44,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 31
   },
   "transform-es2015-object-super": {
@@ -91,6 +118,9 @@
     "safari": 10,
     "node": 5,
     "ios": 10,
+    "chrome-flag": 46,
+    "edge-flag": 13,
+    "node-flag": 5,
     "opera": 33
   },
   "transform-es2015-parameters": {
@@ -100,6 +130,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 49,
+    "edge-flag": 13,
+    "node-flag": 6,
     "opera": 36
   },
   "transform-es2015-shorthand-properties": {
@@ -109,6 +142,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 41,
+    "edge-flag": 12,
+    "node-flag": 4,
     "opera": 30
   },
   "transform-es2015-spread": {
@@ -118,6 +154,9 @@
     "safari": 10,
     "node": 5,
     "ios": 10,
+    "chrome-flag": 46,
+    "edge-flag": 13,
+    "node-flag": 4,
     "opera": 33
   },
   "transform-es2015-sticky-regex": {
@@ -127,6 +166,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 39,
+    "edge-flag": 12,
+    "node-flag": 6,
     "opera": 36
   },
   "transform-es2015-template-literals": {
@@ -136,6 +178,9 @@
     "safari": 9,
     "node": 4,
     "ios": 9,
+    "chrome-flag": 41,
+    "edge-flag": 13,
+    "node-flag": 4,
     "opera": 28
   },
   "transform-es2015-typeof-symbol": {
@@ -145,6 +190,9 @@
     "safari": 9,
     "node": 0.12,
     "ios": 9,
+    "chrome-flag": 30,
+    "edge-flag": 12,
+    "node-flag": 0.12,
     "opera": 25
   },
   "transform-es2015-unicode-regex": {
@@ -154,6 +202,9 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": 50,
+    "edge-flag": 13,
+    "node-flag": 6,
     "opera": 37
   },
   "transform-regenerator": {
@@ -162,23 +213,33 @@
     "safari": 10,
     "node": 6,
     "ios": 10,
+    "chrome-flag": null,
+    "edge-flag": 13,
+    "node-flag": 6,
     "opera": 37
   },
   "transform-exponentiation-operator": {
     "chrome": 52,
     "edge": 14,
     "firefox": 52,
+    "chrome-flag": 51,
+    "edge-flag": 14,
+    "node-flag": 6.5,
     "opera": 39
   },
   "transform-async-to-generator": {
     "chrome": 55,
     "firefox": 52,
+    "chrome-flag": 55,
+    "edge-flag": 14,
     "opera": 42
   },
   "syntax-trailing-function-commas": {
     "edge": 14,
     "firefox": 52,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "chrome-flag": 57,
+    "edge-flag": 14
   }
 }


### PR DESCRIPTION
If you're targeting node --harmony you can use node-flags: 6.5