### PR TITLE
Optimize result filtration.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,25 +226,22 @@ export default function buildPreset(context, opts = {}) {
     }
   }
 
-  let allTransformations = [...transformations, ...whitelist];
-  let regenerator = allTransformations.indexOf("transform-regenerator") >= 0;
+  const allTransformations = [...transformations, ...whitelist];
+  const regenerator = allTransformations.indexOf("transform-regenerator") >= 0;
+  const modulePlugin = moduleType !== false && MODULE_TRANSFORMATIONS[moduleType];
+  const plugins = [];
+  
+  modulePlugin &&
+    plugins.push([require(`babel-plugin-${modulePlugin}`), { loose }]);
 
-  let plugins = allTransformations.map((pluginName) => {
-    return [require(`babel-plugin-${pluginName}`), { loose }];
-  });
+  plugins.push(...allTransformations.map((pluginName) =>
+    [require(`babel-plugin-${pluginName}`), { loose }]
+  ));
 
-  const modules = [
-    moduleType === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose }],
-    moduleType === "systemjs" && [require("babel-plugin-transform-es2015-modules-systemjs"), { loose }],
-    moduleType === "amd" && [require("babel-plugin-transform-es2015-modules-amd"), { loose }],
-    moduleType === "umd" && [require("babel-plugin-transform-es2015-modules-umd"), { loose }],
-  ].filter(Boolean);
+  useBuiltIns &&
+    plugins.push([transformPolyfillRequirePlugin, { polyfills, regenerator }]);
 
   return {
-    plugins: [
-      ...modules,
-      ...plugins,
-      useBuiltIns === true && [transformPolyfillRequirePlugin, { polyfills, regenerator }]
-    ].filter(Boolean)
+    plugins
   };
 }


### PR DESCRIPTION
**Why?**
For now, we have excess `.filter(Boolean)` while processing preset's result:
Firstly, there are extra checks for modules:

```js
const modules = [
// false
  moduleType === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose }],
// false
  moduleType === "systemjs" && [require("babel-plugin-transform-es2015-modules-systemjs"), { loose }],
// false
  moduleType === "amd" && [require("babel-plugin-transform-es2015-modules-amd"), { loose }],
// true
  moduleType === "umd" && [require("babel-plugin-transform-es2015-modules-umd"), { loose }],
].filter(Boolean);
// Up to 4 checks
```
Then we iterate all modules array to get only single matched module:
```js
modules.filter(Boolean)
```

By the end, we are processing new iteration by filtering preset's result:
```js
plugins: [
  ...modules,
  ...plugins,
  useBuiltIns === true && [transformPolyfillRequirePlugin, { polyfills, regenerator }]
].filter(Boolean)
```
despite:
1. we've already checked `modules` array
2. `plugins` can't contain anything except array(it's result of `allTransformations.map` which returns array only and throws error if no plugin was found).
So, we are iterating the whole array to check only last value.

**How this PR optimizes aforesaid?**

1. We already have `MODULE_TRANSFORMATIONS` to check and get module's plugin.
2. Replace array filtering with particular checks.
3. Fill up preset's result gradually.