### PR TITLE
Refactor build data for clarity/consistency

### DIFF
--- a/data/builtIns.json
+++ b/data/builtIns.json
@@ -100,158 +100,158 @@
   },
   "es6.map": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.set": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.weak-map": {
     "chrome": 51,
-    "opera": 38,
     "safari": 9,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.weak-set": {
     "chrome": 51,
-    "opera": 38,
     "safari": 9,
-    "ios": 9
+    "ios": 9,
+    "opera": 38
   },
   "es6.reflect.apply": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.construct": {
     "chrome": 49,
-    "opera": 36,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.define-property": {
     "chrome": 49,
-    "opera": 36,
     "edge": 13,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.delete-property": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.get": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.get-own-property-descriptor": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.get-prototype-of": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.has": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.is-extensible": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.own-keys": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.prevent-extensions": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.set": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.reflect.set-prototype-of": {
     "chrome": 49,
-    "opera": 36,
     "edge": 12,
     "firefox": 42,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "es6.promise": {
     "chrome": 51,
-    "opera": 38,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.symbol": {
     "chrome": 51,
-    "opera": 38,
     "firefox": 51,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.object.assign": {
     "chrome": 45,
-    "opera": 32,
     "edge": 12,
     "firefox": 34,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 32
   },
   "es6.object.is": {
     "chrome": 19,
@@ -264,182 +264,182 @@
   },
   "es6.object.set-prototype-of": {
     "chrome": 34,
-    "opera": 21,
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
     "ie": 11,
-    "ios": 9
+    "ios": 9,
+    "opera": 21
   },
   "es6.function.name": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.string.raw": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 34,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.string.from-code-point": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 29,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.string.code-point-at": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 29,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.string.repeat": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 24,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.string.starts-with": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 29,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.string.ends-with": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 29,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.string.includes": {
     "chrome": 41,
-    "opera": 28,
     "edge": 12,
     "firefox": 40,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "es6.regexp.flags": {
     "chrome": 49,
-    "opera": 36,
     "firefox": 37,
     "safari": 9,
-    "ios": 9
+    "ios": 9,
+    "opera": 36
   },
   "es6.regexp.match": {
     "chrome": 50,
-    "opera": 37,
     "firefox": 49,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 37
   },
   "es6.regexp.replace": {
     "chrome": 50,
-    "opera": 37,
     "firefox": 49,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 37
   },
   "es6.regexp.split": {
     "chrome": 50,
-    "opera": 37,
     "firefox": 49,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 37
   },
   "es6.regexp.search": {
     "chrome": 50,
-    "opera": 37,
     "firefox": 49,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 37
   },
   "es6.array.from": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "es6.array.of": {
     "chrome": 45,
-    "opera": 32,
     "edge": 12,
     "firefox": 25,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 32
   },
   "es6.array.copy-within": {
     "chrome": 45,
-    "opera": 32,
     "edge": 12,
     "firefox": 32,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 32
   },
   "es6.array.find": {
     "chrome": 45,
-    "opera": 32,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 4,
-    "ios": 10
+    "ios": 10,
+    "opera": 32
   },
   "es6.array.find-index": {
     "chrome": 45,
-    "opera": 32,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 4,
-    "ios": 10
+    "ios": 10,
+    "opera": 32
   },
   "es6.array.fill": {
     "chrome": 45,
-    "opera": 32,
     "edge": 12,
     "firefox": 31,
     "safari": 7,
     "node": 4,
-    "ios": 10
+    "ios": 10,
+    "opera": 32
   },
   "es6.array.iterator": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 28,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.number.is-finite": {
     "chrome": 19,
@@ -452,21 +452,21 @@
   },
   "es6.number.is-integer": {
     "chrome": 34,
-    "opera": 21,
     "edge": 12,
     "firefox": 16,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 21
   },
   "es6.number.is-safe-integer": {
     "chrome": 34,
-    "opera": 21,
     "edge": 12,
     "firefox": 32,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 21
   },
   "es6.number.is-nan": {
     "chrome": 19,
@@ -479,212 +479,212 @@
   },
   "es6.number.epsilon": {
     "chrome": 34,
-    "opera": 21,
     "edge": 12,
     "firefox": 25,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 21
   },
   "es6.number.min-safe-integer": {
     "chrome": 34,
-    "opera": 21,
     "edge": 12,
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 21
   },
   "es6.number.max-safe-integer": {
     "chrome": 34,
-    "opera": 21,
     "edge": 12,
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 21
   },
   "es6.math.acosh": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.asinh": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.atanh": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.cbrt": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.clz32": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 25
   },
   "es6.math.cosh": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.expm1": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.fround": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 26,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.hypot": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 27,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.imul": {
     "chrome": 30,
-    "opera": 17,
     "edge": 12,
     "firefox": 23,
     "safari": 7,
     "node": 0.12,
     "android": 4.4,
-    "ios": 8
+    "ios": 8,
+    "opera": 17
   },
   "es6.math.log1p": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.log10": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.log2": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.sign": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 25
   },
   "es6.math.sinh": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.tanh": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es6.math.trunc": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 25,
     "safari": 7,
     "node": 0.12,
-    "ios": 10
+    "ios": 10,
+    "opera": 25
   },
   "es7.array.includes.js": {
     "chrome": 47,
-    "opera": 34,
     "edge": 14,
     "firefox": 43,
     "safari": 10,
-    "ios": 10
+    "ios": 10,
+    "opera": 34
   },
   "es7.object.values": {
     "chrome": 54,
-    "opera": 41,
     "edge": 14,
     "firefox": 47,
-    "node": 7
+    "node": 7,
+    "opera": 41
   },
   "es7.object.entries": {
     "chrome": 54,
-    "opera": 41,
     "edge": 14,
     "firefox": 47,
-    "node": 7
+    "node": 7,
+    "opera": 41
   },
   "es7.object.get-own-property-descriptors": {
     "chrome": 54,
-    "opera": 41,
     "firefox": 50,
-    "node": 7
+    "node": 7,
+    "opera": 41
   },
   "es7.string.pad-start": {
     "firefox": 48,

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -1,174 +1,174 @@
 {
   "transform-es2015-arrow-functions": {
     "chrome": 47,
-    "opera": 34,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 34
   },
   "transform-es2015-block-scoped-functions": {
     "chrome": 41,
-    "opera": 28,
     "firefox": 46,
     "safari": 10,
     "node": 4,
     "ie": 11,
-    "ios": 10
+    "ios": 10,
+    "opera": 28
   },
   "transform-es2015-block-scoping": {
     "chrome": 49,
-    "opera": 36,
     "firefox": 51,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "transform-es2015-classes": {
     "chrome": 46,
-    "opera": 33,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
     "node": 5,
-    "ios": 10
+    "ios": 10,
+    "opera": 33
   },
   "transform-es2015-computed-properties": {
     "chrome": 44,
-    "opera": 31,
     "edge": 12,
     "firefox": 34,
     "safari": 7,
     "node": 4,
-    "ios": 10
+    "ios": 10,
+    "opera": 31
   },
   "check-es2015-constants": {
     "chrome": 49,
-    "opera": 36,
     "firefox": 51,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "transform-es2015-destructuring": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "transform-es2015-for-of": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "transform-es2015-function-name": {
     "chrome": 51,
-    "opera": 38,
     "safari": 10,
     "node": 6.5,
-    "ios": 10
+    "ios": 10,
+    "opera": 38
   },
   "transform-es2015-literals": {
     "chrome": 44,
-    "opera": 31,
     "edge": 12,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 31
   },
   "transform-es2015-object-super": {
     "chrome": 46,
-    "opera": 33,
     "edge": 13,
     "firefox": 45,
     "safari": 10,
     "node": 5,
-    "ios": 10
+    "ios": 10,
+    "opera": 33
   },
   "transform-es2015-parameters": {
     "chrome": 49,
-    "opera": 36,
     "edge": 14,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "transform-es2015-shorthand-properties": {
     "chrome": 43,
-    "opera": 30,
     "edge": 12,
     "firefox": 33,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 30
   },
   "transform-es2015-spread": {
     "chrome": 46,
-    "opera": 33,
     "edge": 13,
     "firefox": 36,
     "safari": 10,
     "node": 5,
-    "ios": 10
+    "ios": 10,
+    "opera": 33
   },
   "transform-es2015-sticky-regex": {
     "chrome": 49,
-    "opera": 36,
     "edge": 13,
     "firefox": 3,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 36
   },
   "transform-es2015-template-literals": {
     "chrome": 41,
-    "opera": 28,
     "edge": 13,
     "firefox": 34,
     "safari": 9,
     "node": 4,
-    "ios": 9
+    "ios": 9,
+    "opera": 28
   },
   "transform-es2015-typeof-symbol": {
     "chrome": 38,
-    "opera": 25,
     "edge": 12,
     "firefox": 36,
     "safari": 9,
     "node": 0.12,
-    "ios": 9
+    "ios": 9,
+    "opera": 25
   },
   "transform-es2015-unicode-regex": {
     "chrome": 50,
-    "opera": 37,
     "edge": 13,
     "firefox": 46,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 37
   },
   "transform-regenerator": {
     "chrome": 50,
-    "opera": 37,
     "edge": 13,
     "safari": 10,
     "node": 6,
-    "ios": 10
+    "ios": 10,
+    "opera": 37
   },
   "transform-exponentiation-operator": {
     "chrome": 52,
-    "opera": 39,
     "edge": 14,
-    "firefox": 52
+    "firefox": 52,
+    "opera": 39
   },
   "transform-async-to-generator": {
     "chrome": 55,
-    "opera": 42,
-    "firefox": 52
+    "firefox": 52,
+    "opera": 42
   },
   "syntax-trailing-function-commas": {
     "edge": 14,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "build-data": "babel-node ./scripts/build-data.js",
+    "build-data": "node ./scripts/build-data.js",
     "dev": "babel -w src -d lib",
     "lint": "eslint scripts src test",
     "fix": "eslint scripts src test --fix",


### PR DESCRIPTION
This PR makes 5 updates to the `build-data.js` script.

* The `package.json` was changed to not rely on Babel. Node6 obviates the need for this 🎊 !
* `environments` are passed to `generateData` making it a pure function of it's arguments
*  `generateData` was changed to use `mapValues` in place of `Object.keys(obj).forEach(...)`
* Adding data for Opera was moved outside of a loop. Now it's only run once 🙃 
* Indentation of prototype methods was made to consistently be 2 spaces.