### PR TITLE
Update linting rules to cover all js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
+/lib
 fixtures

--- a/data/builtInFeatures.js
+++ b/data/builtInFeatures.js
@@ -57,7 +57,7 @@ const es2015 = {
   "es6.object.is": "Object static methods / Object.is",
   "es6.object.set-prototype-of": "Object static methods / Object.setPrototypeOf",
 
-  "es6.function.name": 'function "name" property',
+  "es6.function.name": "function \"name\" property",
 
   "es6.string.raw": "String static methods / String.raw",
   "es6.string.from-code-point": "String static methods / String.fromCodePoint",
@@ -84,11 +84,11 @@ const es2015 = {
   "es6.array.fill": "Array.prototype methods / Array.prototype.fill",
 
   "es6.array.iterator": {
-   features: [
-     "Array.prototype methods / Array.prototype.keys",
+    features: [
+      "Array.prototype methods / Array.prototype.keys",
      // can use Symbol.iterator, not implemented in many environments
      // "Array.prototype methods / Array.prototype.values",
-     "Array.prototype methods / Array.prototype.entries",
+      "Array.prototype methods / Array.prototype.entries",
     ]
   },
 

--- a/data/pluginFeatures.js
+++ b/data/pluginFeatures.js
@@ -46,7 +46,7 @@ module.exports = {
   },
   "transform-es2015-function-name": {
     features: [
-      'function "name" property',
+      "function \"name\" property",
     ]
   },
   "transform-es2015-literals": {
@@ -77,8 +77,8 @@ module.exports = {
   },
   "transform-es2015-sticky-regex": {
     features: [
-      'RegExp "y" and "u" flags / "y" flag, lastIndex',
-      'RegExp "y" and "u" flags / "y" flag',
+      "RegExp \"y\" and \"u\" flags / \"y\" flag, lastIndex",
+      "RegExp \"y\" and \"u\" flags / \"y\" flag",
     ],
   },
   "transform-es2015-template-literals": {
@@ -93,9 +93,9 @@ module.exports = {
   },
   "transform-es2015-unicode-regex": {
     features: [
-      'RegExp "y" and "u" flags / "u" flag, case folding',
-      'RegExp "y" and "u" flags / "u" flag, Unicode code point escapes',
-      'RegExp "y" and "u" flags / "u" flag',
+      "RegExp \"y\" and \"u\" flags / \"u\" flag, case folding",
+      "RegExp \"y\" and \"u\" flags / \"u\" flag, Unicode code point escapes",
+      "RegExp \"y\" and \"u\" flags / \"u\" flag",
     ],
   },
   "transform-regenerator": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "babel src -d lib",
     "build-data": "babel-node ./scripts/build-data.js",
     "dev": "babel -w src -d lib",
-    "lint": "eslint scripts src test",
-    "fix": "eslint scripts src test --fix",
+    "lint": "eslint .",
+    "fix": "eslint . --fix",
     "ci": "npm run test",
     "changelog": "git log `git describe --tags --abbrev=0`..HEAD --pretty=format:' * %s (%an)' | grep -v 'Merge pull request'",
     "test": "npm run build && mocha ./test --compilers js:babel-register -t 5000"


### PR DESCRIPTION
This PR updates the linting to cover all files including those in the data directory since they appear to be (for now) hand generated. In the future, it may be good to just add the `/data` directory to the `.eslintignore`.