### PR TITLE
Drop support for node 0.10 and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ node_js:
 - '7'
 - '6'
 - '4'
-- '0.12'
-- '0.10'
 script:
   - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
   - 'if [ -z "${LINT-}" ]; then npm run ci ; fi'


### PR DESCRIPTION
No other babel projects still support the 0.10 / 0.12 Node versions. Lets save a few CPU cycles for travis and drop them here too.