### PR TITLE
Show error if target version is not a number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,12 @@ export const isPluginRequired = (supportedEnvironments, plugin) => {
       const lowestImplementedVersion = plugin[environment];
       const lowestTargetedVersion = supportedEnvironments[environment];
 
-      if (lowestTargetedVersion < lowestImplementedVersion) {
-        return true;
+      if (typeof lowestTargetedVersion === "string") {
+        throw new Error(`Target version must be a number, 
+          '${lowestTargetedVersion}' was given for '${environment}'`);
       }
 
-      return false;
+      return lowestTargetedVersion < lowestImplementedVersion;
     });
 
   return isRequiredForEnvironments.length > 0 ? true : false;

--- a/test/index.js
+++ b/test/index.js
@@ -159,6 +159,20 @@ describe("babel-preset-env", () => {
         babelPresetEnv.isPluginRequired(targets, plugin);
       }, Error);
     });
+
+    it("will throw if target version is not a number", () => {
+      const plugin = {
+        "node": 6,
+      };
+
+      const targets = {
+        "node": "6.5",
+      };
+
+      assert.throws(() => {
+        babelPresetEnv.isPluginRequired(targets, plugin);
+      }, Error);
+    });
   });
 
   describe("validateLooseOption", () => {


### PR DESCRIPTION
Fixes #106 for now since the docs/examples all state number.

We can follow up with string support later.