### PR TITLE
Fix targets for debug.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -257,7 +257,7 @@ export default function buildPreset(context, opts = {}) {
     hasBeenLogged = true;
     console.log("babel-preset-env: `DEBUG` option");
     console.log("\nUsing targets:");
-    console.log(JSON.stringify(opts.targets, null, 2));
+    console.log(JSON.stringify(targets, null, 2));
     console.log(`\nModules transform: ${moduleType}`);
     console.log("\nUsing plugins:");
     transformations.forEach((transform) => {

--- a/src/index.js
+++ b/src/index.js
@@ -221,7 +221,7 @@ const logPlugin = (plugin, targets, list) => {
     a[b] = envList[b];
     return a;
   }, {});
-  const logStr = `\n ${plugin} ${JSON.stringify(filteredList)}`;
+  const logStr = `\n  ${plugin}\n  ${JSON.stringify(filteredList)}`;
   console.log(logStr);
 };
 
@@ -256,19 +256,17 @@ export default function buildPreset(context, opts = {}) {
   if (debug && !hasBeenLogged) {
     hasBeenLogged = true;
     console.log("babel-preset-env: `DEBUG` option");
-    console.log("");
-    console.log(`Using targets: ${JSON.stringify(opts.targets, null, 2)}`);
-    console.log("");
-    console.log(`modules transform: ${moduleType}`);
-    console.log("");
-    console.log("Using plugins:");
+    console.log("\nUsing targets:");
+    console.log(JSON.stringify(opts.targets, null, 2));
+    console.log(`\nModules transform: ${moduleType}`);
+    console.log("\nUsing plugins:");
     transformations.forEach((transform) => {
-      logPlugin(transform, opts.targets, pluginList);
+      logPlugin(transform, targets, pluginList);
     });
     console.log("\nUsing polyfills:");
     if (useBuiltIns && polyfills.length) {
       polyfills.forEach((polyfill) => {
-        logPlugin(polyfill, opts.targets, builtInsList);
+        logPlugin(polyfill, targets, builtInsList);
       });
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -221,7 +221,7 @@ const logPlugin = (plugin, targets, list) => {
     a[b] = envList[b];
     return a;
   }, {});
-  const logStr = `\n  ${plugin}\n  ${JSON.stringify(filteredList)}`;
+  const logStr = `  ${plugin} ${JSON.stringify(filteredList)}`;
   console.log(logStr);
 };
 


### PR DESCRIPTION
**Fix bug**: Logger receives targets directly from opts where `browsers` isn't parsed yet. 

**Enhancement**: Remove empty line between plugin items, capitalize *modules transform*, add extra space ahead of plugin name.

*Before:*
```
Using targets: {
  "browsers": "last 2 chrome versions, ie 10",
  "node": 6
}

modules transform: false

Using plugins:

 transform-es2015-arrow-functions {"node":6}

 transform-es2015-block-scoped-functions {"node":4}

Using polyfills:

 es6.typed.uint8-clamped-array {"node":0.12}

 es6.map {"node":6.5}

```


After: 
```
Using targets:
{
  "chrome": 53,
  "ie": 10,
  "node": 6
}

Modules transform: false

Using plugins:
  transform-es2015-arrow-functions {"chrome":47,"node":6}
  transform-es2015-block-scoped-functions {"chrome":41,"ie":11,"node":4}

Using polyfills:
  es6.typed.uint8-clamped-array {"chrome":5,"node":0.12}
  es6.map {"chrome":51,"node":6.5}
```
