### PR TITLE
Extract option normalization into independant file

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
     "babel-plugin-transform-exponentiation-operator": "^6.8.0",
     "babel-plugin-transform-regenerator": "^6.6.0",
-    "browserslist": "^1.4.0"
+    "browserslist": "^1.4.0",
+    "invariant": "^2.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/default-includes.js
+++ b/src/default-includes.js
@@ -1,0 +1,5 @@
+export default [
+  "web.timers",
+  "web.immediate",
+  "web.dom.iterable"
+];

--- a/src/module-transformations.js
+++ b/src/module-transformations.js
@@ -1,0 +1,6 @@
+export default {
+  "amd": "transform-es2015-modules-amd",
+  "commonjs": "transform-es2015-modules-commonjs",
+  "systemjs": "transform-es2015-modules-systemjs",
+  "umd": "transform-es2015-modules-umd"
+};

--- a/src/normalize-options.js
+++ b/src/normalize-options.js
@@ -1,0 +1,93 @@
+import intersection from "lodash/intersection";
+import invariant from "invariant";
+
+import builtInsList from "../data/built-ins.json";
+import defaultInclude from "./default-includes";
+import moduleTransformations from "./module-transformations";
+import pluginFeatures from "../data/plugin-features";
+
+const hasBeenWarned = false;
+
+const validIncludesAndExcludes = [
+  ...Object.keys(pluginFeatures),
+  ...Object.keys(moduleTransformations).map((m) => moduleTransformations[m]),
+  ...Object.keys(builtInsList),
+  ...defaultInclude
+];
+
+export const validateIncludesAndExcludes = (opts = [], type) => {
+  invariant(
+    Array.isArray(opts),
+    `Invalid Option: The '${type}' option must be an Array<String> of plugins/built-ins`
+  );
+
+  const unknownOpts = opts.filter((opt) => !validIncludesAndExcludes.includes(opt));
+
+  invariant(
+    unknownOpts.length === 0,
+    `Invalid Option: The plugins/built-ins '${unknownOpts}' passed to the '${type}' option are not
+    valid. Please check data/[plugin-features|built-in-features].js in babel-preset-env`
+  );
+
+  return opts;
+};
+
+export const checkDuplicateIncludeExcludes = (include = [], exclude = []) => {
+  const duplicates = intersection(include, exclude);
+
+  invariant(
+    duplicates.length === 0,
+    `Invalid Option: The plugins/built-ins '${duplicates}' were found in both the "include" and
+    "exclude" options.`
+  );
+};
+
+// TODO: Allow specifying plugins as either shortened or full name
+// babel-plugin-transform-es2015-classes
+// transform-es2015-classes
+export const validateLooseOption = (looseOpt = false) => {
+  invariant(
+    typeof looseOpt === "boolean",
+    "Invalid Option: The 'loose' option must be a boolean."
+  );
+
+  return looseOpt;
+};
+
+export const validateModulesOption = (modulesOpt = "commonjs") => {
+  invariant(
+    modulesOpt === false || Object.keys(moduleTransformations).includes(modulesOpt),
+    `Invalid Option: The 'modules' option must be either 'false' to indicate no modules, or a
+    module type which can be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'.`
+  );
+
+  return modulesOpt;
+};
+
+export default function normalizeOptions(opts) {
+  // TODO: remove whitelist in favor of include in next major
+  if (opts.whitelist && !hasBeenWarned) {
+    console.warn(
+      `Deprecation Warning: The "whitelist" option has been deprecated in favor of "include" to
+      match the newly added "exclude" option (instead of "blacklist").`
+    );
+  }
+
+  invariant(
+    !(opts.whitelist && opts.include),
+    `Invalid Option: The "whitelist" and the "include" option are the same and one can be used at
+    a time`
+  );
+
+  checkDuplicateIncludeExcludes(opts.whitelist || opts.include, opts.exclude);
+
+  return {
+    debug: opts.debug,
+    exclude: validateIncludesAndExcludes(opts.exclude, "exclude"),
+    include: validateIncludesAndExcludes(opts.whitelist || opts.include, "include"),
+    loose: validateLooseOption(opts.loose),
+    moduleType: validateModulesOption(opts.modules),
+    targets: opts.targets,
+    useBuiltIns: opts.useBuiltIns
+  };
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,13 +4,6 @@ const babelPresetEnv = require("../lib/index.js");
 const assert = require("assert");
 const electronToChromiumData = require("../data/electron-to-chromium");
 
-const {
-  validateModulesOption,
-  validateLooseOption,
-  validatePluginsOption,
-  checkDuplicateIncludeExcludes
-} = babelPresetEnv;
-
 describe("babel-preset-env", () => {
   describe("getTargets", () => {
     it("should return the current node version with option 'current'", function() {
@@ -173,115 +166,27 @@ describe("babel-preset-env", () => {
     });
   });
 
-  describe("validateLooseOption", () => {
-    it("`undefined` option returns false", () => {
-      assert(validateLooseOption() === false);
+  describe("transformIncludesAndExculdes", function() {
+    it("should return in transforms array", function() {
+      assert.deepEqual(
+        babelPresetEnv.transformIncludesAndExculdes(["transform-es2015-arrow-functions"]),
+        {
+          all: ["transform-es2015-arrow-functions"],
+          plugins: ["transform-es2015-arrow-functions"],
+          builtIns: []
+        }
+      );
     });
 
-    it("`false` option returns false", () => {
-      assert(validateLooseOption(false) === false);
-    });
-
-    it("`true` option returns true", () => {
-      assert(validateLooseOption(true) === true);
-    });
-
-    it("array option is invalid", () => {
-      assert.throws(() => {
-        validateModulesOption([]);
-      }, Error);
-    });
-  });
-
-  describe("validateModulesOption", () => {
-    it("`undefined` option returns commonjs", () => {
-      assert(validateModulesOption() === "commonjs");
-    });
-
-    it("`false` option returns commonjs", () => {
-      assert(validateModulesOption(false) === false);
-    });
-
-    it("commonjs option is valid", () => {
-      assert(validateModulesOption("commonjs") === "commonjs");
-    });
-
-    it("systemjs option is valid", () => {
-      assert(validateModulesOption("systemjs") === "systemjs");
-    });
-
-    it("amd option is valid", () => {
-      assert(validateModulesOption("amd") === "amd");
-    });
-
-    it("umd option is valid", () => {
-      assert(validateModulesOption("umd") === "umd");
-    });
-
-    it("`true` option is invalid", () => {
-      assert.throws(() => {
-        validateModulesOption(true);
-      }, Error);
-    });
-
-    it("array option is invalid", () => {
-      assert.throws(() => {
-        assert(validateModulesOption([]));
-      }, Error);
-    });
-
-    describe("validatePluginsOption", function() {
-      it("should return empty arrays if undefined", function() {
-        assert.deepEqual(validatePluginsOption(), { all: [], plugins: [], builtIns: [] });
-      });
-
-      it("should return in transforms array", function() {
-        assert.deepEqual(
-          validatePluginsOption(["transform-es2015-arrow-functions"]),
-          {
-            all: ["transform-es2015-arrow-functions"],
-            plugins: ["transform-es2015-arrow-functions"],
-            builtIns: []
-          }
-        );
-      });
-
-      it("should return in built-ins array", function() {
-        assert.deepEqual(
-          validatePluginsOption(["es6.map"]),
-          {
-            all: ["es6.map"],
-            plugins: [],
-            builtIns: ["es6.map"]
-          }
-        );
-      });
-
-      it("should throw if not in features", function() {
-        assert.throws(() => {
-          validatePluginsOption(["asdf"]);
-        }, Error);
-      });
-    });
-
-    describe("checkDuplicateIncludeExcludes", function() {
-      it("should throw if duplicate names in both", function() {
-        assert.throws(() => {
-          checkDuplicateIncludeExcludes(
-            ["transform-regenerator", "map"],
-            ["transform-regenerator", "map"]
-          );
-        }, Error);
-      });
-
-      it("should not throw if no duplicate names in both", function() {
-        assert.doesNotThrow(() => {
-          checkDuplicateIncludeExcludes(
-            ["transform-regenerator"],
-            ["map"]
-          );
-        }, Error);
-      });
+    it("should return in built-ins array", function() {
+      assert.deepEqual(
+        babelPresetEnv.transformIncludesAndExculdes(["es6.map"]),
+        {
+          all: ["es6.map"],
+          plugins: [],
+          builtIns: ["es6.map"]
+        }
+      );
     });
   });
 });

--- a/test/normalize-options.spec.js
+++ b/test/normalize-options.spec.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const normalizeOptions = require("../lib/normalize-options.js");
+const assert = require("assert");
+
+const {
+  checkDuplicateIncludeExcludes,
+  validateIncludesAndExcludes,
+  validateLooseOption,
+  validateModulesOption
+} = normalizeOptions;
+
+describe("normalize-options", () => {
+  describe("validateLooseOption", () => {
+    it("`undefined` option returns false", () => {
+      assert(validateLooseOption() === false);
+    });
+
+    it("`false` option returns false", () => {
+      assert(validateLooseOption(false) === false);
+    });
+
+    it("`true` option returns true", () => {
+      assert(validateLooseOption(true) === true);
+    });
+
+    it("array option is invalid", () => {
+      assert.throws(() => {
+        validateLooseOption([]);
+      }, Error);
+    });
+  });
+
+  describe("checkDuplicateIncludeExcludes", function() {
+    it("should throw if duplicate names in both", function() {
+      assert.throws(() => {
+        checkDuplicateIncludeExcludes(
+          ["transform-regenerator", "map"],
+          ["transform-regenerator", "map"]
+        );
+      }, Error);
+    });
+
+    it("should not throw if no duplicate names in both", function() {
+      assert.doesNotThrow(() => {
+        checkDuplicateIncludeExcludes(
+          ["transform-regenerator"],
+          ["map"]
+        );
+      }, Error);
+    });
+  });
+
+  describe("validateModulesOption", () => {
+    it("`undefined` option returns commonjs", () => {
+      assert(validateModulesOption() === "commonjs");
+    });
+
+    it("`false` option returns commonjs", () => {
+      assert(validateModulesOption(false) === false);
+    });
+
+    it("commonjs option is valid", () => {
+      assert(validateModulesOption("commonjs") === "commonjs");
+    });
+
+    it("systemjs option is valid", () => {
+      assert(validateModulesOption("systemjs") === "systemjs");
+    });
+
+    it("amd option is valid", () => {
+      assert(validateModulesOption("amd") === "amd");
+    });
+
+    it("umd option is valid", () => {
+      assert(validateModulesOption("umd") === "umd");
+    });
+
+    it("`true` option is invalid", () => {
+      assert.throws(() => {
+        validateModulesOption(true);
+      }, Error);
+    });
+
+    it("array option is invalid", () => {
+      assert.throws(() => {
+        assert(validateModulesOption([]));
+      }, Error);
+    });
+  });
+  describe("validateIncludesAndExcludes", function() {
+    it("should return empty arrays if undefined", function() {
+      assert.deepEqual(validateIncludesAndExcludes(), []);
+    });
+    it("should throw if not in features", function() {
+      assert.throws(() => {
+        validateIncludesAndExcludes(["asdf"]);
+      }, Error);
+    });
+  });
+});


### PR DESCRIPTION
This PR moves all preset option validation logic into a separate file. 95% of this PR is simply moving code from the `index.js` => `normalize-options.js` with the exception of the following:

- Error messages were edited for clarity and consistency. They are now of the format `Invalid Option: <problem>` or `Deprecation Warning: <problem>`
- The `invariant` library was pulled in to help make the code a bit more readable.
- With the exception of setting default values, `normalizeOptions` does not mutate or change the input object. Part of what set me down the path of this refactor was unexpectedly finding that `validateIncludeOption` and `validateExcludeOption` not only altered the input but changed the shape.
- `lodash/intersection` was pulled into the plugin bundle for clarity.

Thanks for all the great work on this repo! If you find this change too invasive, I'm happy to try to scale back in places. The impetus for all of this was finding that validation was actually mutating which could be fixed in other ways. Thanks for doing all ya'll do here!