### PR TITLE
Transformations before logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ const filterItem = (targets, exclusions, list, item) => {
   if (isDefault) return notExcluded;
   const isRequired = isPluginRequired(targets, list[item]);
   return isRequired && notExcluded;
-}
+};
 
 export default function buildPreset(context, opts = {}) {
   const loose = validateLooseOption(opts.loose);

--- a/src/index.js
+++ b/src/index.js
@@ -230,11 +230,10 @@ const logPlugin = (plugin, targets, list) => {
 
 const filterItem = (targets, exclusions, list, item) => {
   const isDefault = defaultInclude.indexOf(item) >= 0;
-  if (isDefault) return true;
-
-  const isRequired = isPluginRequired(targets, list[item]);
   const notExcluded = exclusions.indexOf(item) === -1;
 
+  if (isDefault) return notExcluded;
+  const isRequired = isPluginRequired(targets, list[item]);
   return isRequired && notExcluded;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -228,6 +228,16 @@ const logPlugin = (plugin, targets, list) => {
   console.log(logStr);
 };
 
+const filterItem = (targets, exclusions, list, item) => {
+  const isDefault = defaultInclude.indexOf(item) >= 0;
+  if (isDefault) return true;
+
+  const isRequired = isPluginRequired(targets, list[item]);
+  const notExcluded = exclusions.indexOf(item) === -1;
+
+  return isRequired && notExcluded;
+}
+
 export default function buildPreset(context, opts = {}) {
   const loose = validateLooseOption(opts.loose);
   const moduleType = validateModulesOption(opts.modules);
@@ -244,15 +254,18 @@ export default function buildPreset(context, opts = {}) {
   const debug = opts.debug;
   const useBuiltIns = opts.useBuiltIns;
 
+  const filterPlugins = filterItem.bind(null, targets, exclude.plugins, pluginList);
   let transformations = Object.keys(pluginList)
-    .filter((pluginName) => isPluginRequired(targets, pluginList[pluginName]));
+    .filter(filterPlugins)
+    .concat(include.plugins);
 
   let polyfills;
   if (useBuiltIns) {
+    const filterBuiltIns = filterItem.bind(null, targets, exclude.builtIns, builtInsList);
+
     polyfills = Object.keys(builtInsList)
-      .filter((builtInName) => isPluginRequired(targets, builtInsList[builtInName]))
       .concat(defaultInclude)
-      .filter((plugin) => exclude.builtIns.indexOf(plugin) === -1)
+      .filter(filterBuiltIns)
       .concat(include.builtIns);
   }
 
@@ -266,26 +279,22 @@ export default function buildPreset(context, opts = {}) {
     transformations.forEach((transform) => {
       logPlugin(transform, targets, pluginList);
     });
-    console.log("\nUsing polyfills:");
     if (useBuiltIns && polyfills.length) {
+      console.log("\nUsing polyfills:");
       polyfills.forEach((polyfill) => {
         logPlugin(polyfill, targets, builtInsList);
       });
     }
   }
 
-  const allTransformations = transformations
-  .filter((plugin) => exclude.plugins.indexOf(plugin) === -1)
-  .concat(include.plugins);
-
-  const regenerator = allTransformations.indexOf("transform-regenerator") >= 0;
+  const regenerator = transformations.indexOf("transform-regenerator") >= 0;
   const modulePlugin = moduleType !== false && MODULE_TRANSFORMATIONS[moduleType];
   const plugins = [];
 
   modulePlugin &&
     plugins.push([require(`babel-plugin-${modulePlugin}`), { loose }]);
 
-  plugins.push(...allTransformations.map((pluginName) =>
+  plugins.push(...transformations.map((pluginName) =>
     [require(`babel-plugin-${pluginName}`), { loose }]
   ));
 


### PR DESCRIPTION
1. Log transformations after `excluded/included` processing. Fixes https://github.com/babel/babel-preset-env/issues/127.
2. Prevent a second iteration by replacing filtration from 2 to 1 call:

*before*
```
items
  .filter((builtInName) => isPluginRequired(targets, pluginsList))
  .filter((plugin) => exclusions.indexOf(plugin) === -1)
```
*now*
```
  const filterBuiltIns = filterItem.bind(null, targets, exclusions, pluginsList)
  items.filter(filterBuiltIns)
```