### PR TITLE
Drop unneeded .js from es7.array.includes

### DIFF
--- a/data/built-in-features.js
+++ b/data/built-in-features.js
@@ -120,7 +120,7 @@ const es2015 = {
 };
 
 const es2016 = {
-  "es7.array.includes.js": "Array.prototype.includes",
+  "es7.array.includes": "Array.prototype.includes",
 };
 
 const es2017 = {

--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -658,7 +658,7 @@
     "ios": 10,
     "opera": 25
   },
-  "es7.array.includes.js": {
+  "es7.array.includes": {
     "chrome": 47,
     "edge": 14,
     "firefox": 43,

--- a/test/fixtures/preset-options/exclude-regenerator/expected.js
+++ b/test/fixtures/preset-options/exclude-regenerator/expected.js
@@ -74,7 +74,7 @@ import "core-js/modules/es6.math.sign";
 import "core-js/modules/es6.math.sinh";
 import "core-js/modules/es6.math.tanh";
 import "core-js/modules/es6.math.trunc";
-import "core-js/modules/es7.array.includes.js";
+import "core-js/modules/es7.array.includes";
 import "core-js/modules/es7.object.values";
 import "core-js/modules/es7.object.entries";
 import "core-js/modules/es7.object.get-own-property-descriptors";

--- a/test/fixtures/preset-options/ios-6/expected.js
+++ b/test/fixtures/preset-options/ios-6/expected.js
@@ -65,7 +65,7 @@ import "core-js/modules/es6.math.sign";
 import "core-js/modules/es6.math.sinh";
 import "core-js/modules/es6.math.tanh";
 import "core-js/modules/es6.math.trunc";
-import "core-js/modules/es7.array.includes.js";
+import "core-js/modules/es7.array.includes";
 import "core-js/modules/es7.object.values";
 import "core-js/modules/es7.object.entries";
 import "core-js/modules/es7.object.get-own-property-descriptors";

--- a/test/fixtures/preset-options/use-builtins-all/expected.js
+++ b/test/fixtures/preset-options/use-builtins-all/expected.js
@@ -74,7 +74,7 @@ import "core-js/modules/es6.math.sign";
 import "core-js/modules/es6.math.sinh";
 import "core-js/modules/es6.math.tanh";
 import "core-js/modules/es6.math.trunc";
-import "core-js/modules/es7.array.includes.js";
+import "core-js/modules/es7.array.includes";
 import "core-js/modules/es7.object.values";
 import "core-js/modules/es7.object.entries";
 import "core-js/modules/es7.object.get-own-property-descriptors";


### PR DESCRIPTION
Fixes #129