### PR TITLE
exponential operator is supported in node >7

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -171,6 +171,7 @@
     "chrome": 52,
     "edge": 14,
     "firefox": 52,
+    "node": 7,
     "opera": 39
   },
   "transform-async-to-generator": {


### PR DESCRIPTION
node 7.0 update v8 to 5.4, and the exponential operator was introduced in 5.2

https://nodejs.org/en/download/releases/
https://v8project.blogspot.de/2016/06/release-52.html

```
❯ nvm install 7.0.0
Downloading and installing node v7.0.0...
Downloading https://nodejs.org/dist/v7.0.0/node-v7.0.0-darwin-x64.tar.gz...
######################################################################## 100,0%
Computing checksum with shasum -a 256
Checksums matched!
Now using node v7.0.0 (npm v3.10.8)

❯ node                                                                            
> 2 ** 2
4
> 
```