### PR TITLE
Respect older versions in invert equals map

### DIFF
--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -438,7 +438,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 4,
-    "ios": 9,
+    "ios": 8,
     "opera": 32
   },
   "es6.array.find-index": {
@@ -447,7 +447,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 4,
-    "ios": 9,
+    "ios": 8,
     "opera": 32
   },
   "es6.array.fill": {
@@ -456,7 +456,7 @@
     "firefox": 31,
     "safari": 8,
     "node": 4,
-    "ios": 9,
+    "ios": 8,
     "opera": 32
   },
   "es6.array.iterator": {
@@ -466,7 +466,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.number.is-finite": {
@@ -544,7 +544,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.asinh": {
@@ -554,7 +554,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.atanh": {
@@ -564,7 +564,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.cbrt": {
@@ -574,7 +574,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.clz32": {
@@ -594,7 +594,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.expm1": {
@@ -604,7 +604,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.fround": {
@@ -614,7 +614,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.hypot": {
@@ -624,7 +624,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.imul": {
@@ -644,7 +644,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.log10": {
@@ -654,7 +654,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.log2": {
@@ -664,7 +664,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.sign": {
@@ -684,7 +684,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.tanh": {
@@ -694,7 +694,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es6.math.trunc": {
@@ -704,7 +704,7 @@
     "safari": 8,
     "node": 0.12,
     "android": 5.1,
-    "ios": 9,
+    "ios": 8,
     "opera": 25
   },
   "es7.array.includes": {

--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -419,7 +419,7 @@
     "edge": 12,
     "firefox": 25,
     "safari": 9,
-    "node": 6,
+    "node": 4,
     "ios": 9,
     "opera": 32
   },
@@ -437,7 +437,7 @@
     "edge": 12,
     "firefox": 25,
     "safari": 8,
-    "node": 6,
+    "node": 4,
     "ios": 9,
     "opera": 32
   },
@@ -446,7 +446,7 @@
     "edge": 12,
     "firefox": 25,
     "safari": 8,
-    "node": 6,
+    "node": 4,
     "ios": 9,
     "opera": 32
   },
@@ -455,7 +455,7 @@
     "edge": 12,
     "firefox": 31,
     "safari": 8,
-    "node": 6,
+    "node": 4,
     "ios": 9,
     "opera": 32
   },

--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -36,6 +36,7 @@
     "firefox": 4,
     "safari": 6,
     "node": 0.12,
+    "android": 4.4,
     "ios": 7
   },
   "es6.typed.int16-array": {
@@ -118,6 +119,7 @@
     "chrome": 51,
     "firefox": 53,
     "safari": 9,
+    "node": 6.5,
     "ios": 9,
     "opera": 38
   },
@@ -126,6 +128,7 @@
     "edge": 15,
     "firefox": 53,
     "safari": 9,
+    "node": 6.5,
     "ios": 9,
     "opera": 38
   },
@@ -134,6 +137,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -142,6 +146,7 @@
     "edge": 13,
     "firefox": 45,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -150,6 +155,7 @@
     "edge": 13,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -158,6 +164,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -166,6 +173,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -174,6 +182,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -182,6 +191,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -190,6 +200,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -198,6 +209,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -206,6 +218,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -214,6 +227,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -222,6 +236,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -230,6 +245,7 @@
     "edge": 12,
     "firefox": 42,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 36
   },
@@ -246,6 +262,7 @@
     "chrome": 51,
     "firefox": 51,
     "safari": 10,
+    "node": 6.5,
     "ios": 10,
     "opera": 38
   },
@@ -273,6 +290,7 @@
     "safari": 9,
     "node": 0.12,
     "ie": 11,
+    "android": 5,
     "ios": 9,
     "opera": 21
   },
@@ -351,6 +369,7 @@
     "chrome": 49,
     "firefox": 37,
     "safari": 9,
+    "node": 6,
     "ios": 9,
     "opera": 36
   },
@@ -400,7 +419,7 @@
     "edge": 12,
     "firefox": 25,
     "safari": 9,
-    "node": 4,
+    "node": 6,
     "ios": 9,
     "opera": 32
   },
@@ -418,7 +437,7 @@
     "edge": 12,
     "firefox": 25,
     "safari": 8,
-    "node": 4,
+    "node": 6,
     "ios": 9,
     "opera": 32
   },
@@ -427,7 +446,7 @@
     "edge": 12,
     "firefox": 25,
     "safari": 8,
-    "node": 4,
+    "node": 6,
     "ios": 9,
     "opera": 32
   },
@@ -436,7 +455,7 @@
     "edge": 12,
     "firefox": 31,
     "safari": 8,
-    "node": 4,
+    "node": 6,
     "ios": 9,
     "opera": 32
   },
@@ -446,6 +465,7 @@
     "firefox": 28,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -464,6 +484,7 @@
     "firefox": 16,
     "safari": 9,
     "node": 0.12,
+    "android": 5,
     "ios": 9,
     "opera": 21
   },
@@ -473,6 +494,7 @@
     "firefox": 32,
     "safari": 9,
     "node": 0.12,
+    "android": 5,
     "ios": 9,
     "opera": 21
   },
@@ -491,6 +513,7 @@
     "firefox": 25,
     "safari": 9,
     "node": 0.12,
+    "android": 5,
     "ios": 9,
     "opera": 21
   },
@@ -500,6 +523,7 @@
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
+    "android": 5,
     "ios": 9,
     "opera": 21
   },
@@ -509,6 +533,7 @@
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
+    "android": 5,
     "ios": 9,
     "opera": 21
   },
@@ -518,6 +543,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -527,6 +553,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -536,6 +563,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -545,6 +573,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -554,6 +583,7 @@
     "firefox": 31,
     "safari": 9,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -563,6 +593,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -572,6 +603,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -581,6 +613,7 @@
     "firefox": 26,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -590,6 +623,7 @@
     "firefox": 27,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -609,6 +643,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -618,6 +653,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -627,6 +663,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -636,6 +673,7 @@
     "firefox": 25,
     "safari": 9,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -645,6 +683,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -654,6 +693,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -663,6 +703,7 @@
     "firefox": 25,
     "safari": 8,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -671,6 +712,7 @@
     "edge": 14,
     "firefox": 43,
     "safari": 10,
+    "node": 6,
     "ios": 10,
     "opera": 34
   },
@@ -678,6 +720,7 @@
     "chrome": 54,
     "edge": 14,
     "firefox": 47,
+    "safari": 10.1,
     "node": 7,
     "opera": 41
   },
@@ -685,6 +728,7 @@
     "chrome": 54,
     "edge": 14,
     "firefox": 47,
+    "safari": 10.1,
     "node": 7,
     "opera": 41
   },
@@ -692,7 +736,7 @@
     "chrome": 54,
     "edge": 15,
     "firefox": 50,
-    "safari": 10,
+    "safari": 10.1,
     "node": 7,
     "opera": 41
   },

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -40,7 +40,7 @@
     "firefox": 34,
     "safari": 8,
     "node": 4,
-    "ios": 9,
+    "ios": 8,
     "opera": 31
   },
   "check-es2015-constants": {

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -146,6 +146,7 @@
     "firefox": 36,
     "safari": 9,
     "node": 0.12,
+    "android": 5.1,
     "ios": 9,
     "opera": 25
   },
@@ -171,11 +172,14 @@
     "chrome": 52,
     "edge": 14,
     "firefox": 52,
+    "safari": 10.1,
+    "node": 7,
     "opera": 39
   },
   "transform-async-to-generator": {
     "chrome": 55,
     "firefox": 52,
+    "safari": 10.1,
     "node": 7.6,
     "opera": 42
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
     "chai": "^3.0.0",
-    "compat-table": "kangax/compat-table#291c758ac618fff6bf5bb2113a5aa046189f93e2",
+    "compat-table": "kangax/compat-table#c38f039b8ea7fadf347d3e300fec3611645e31e9",
     "eslint": "^3.13.1",
     "eslint-config-babel": "^5.0.0",
     "eslint-plugin-flowtype": "^2.29.1",

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -85,8 +85,6 @@ const compatibilityTests = flattenDeep([
   })
 ));
 
-console.log(invertedEqualsEnv);
-
 const getLowestImplementedVersion = ({ features }, env) => {
   const tests = flatten(compatibilityTests
     .filter((test) => {

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -60,7 +60,7 @@ const invertedEqualsEnv = Object.keys(envs)
       if (!isNaN(version)) {
         Object.keys(envs).forEach((equals) => {
           const equalsVersion = parseInt(equals.replace(env, ""), 10);
-          if (equalsVersion <= version) {
+          if (!isNaN(equalsVersion) && equalsVersion <= version) {
             if (!a[equals]) a[equals] = [];
             a[equals].push(b);
           }

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -58,11 +58,12 @@ const invertedEqualsEnv = Object.keys(envs)
     environments.some((env) => {
       // go through all environment names to find the the current one
       // and try to get the version as integer
-      const version = parseInt(checkEnv.replace(env, ""), 10);
+      const version = parseFloat(checkEnv.replace(env, ""));
       if (!isNaN(version)) {
         Object.keys(envs).forEach((equals) => {
+          equals = envMap[equals] || equals;
           // Go through all envs from compat-table and get int version
-          const equalsVersion = parseInt(equals.replace(env, ""), 10);
+          const equalsVersion = parseFloat(equals.replace(env, ""));
           // If the current version is smaller than the version that was mentioned
           // in `equals` we can add an entry, as older versions should include features
           // that newer ones have
@@ -77,8 +78,6 @@ const invertedEqualsEnv = Object.keys(envs)
 
     return a;
   }, {});
-
-invertedEqualsEnv.safari8 = ["ios9"];
 
 const compatibilityTests = flattenDeep([
   es6Data,
@@ -141,7 +140,7 @@ const getLowestImplementedVersion = ({ features }, env) => {
       .filter((test) => tests[i].res[test] === true || tests[i].res[test] === "strict")
       // normalize some keys
       .map((test) => envMap[test] || test)
-      .filter((test) => !isNaN(parseInt(test.replace(env, ""))))
+      .filter((test) => !isNaN(parseFloat(test.replace(env, ""))))
       .shift();
     });
 

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -69,6 +69,7 @@ const invertedEqualsEnv = Object.keys(envs)
           // that newer ones have
           if (!isNaN(equalsVersion) && equalsVersion <= version) {
             if (!a[equals]) a[equals] = [];
+            if (a[equals].indexOf(b) >= 0) return;
             a[equals].push(b);
           }
         });

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -56,10 +56,16 @@ const invertedEqualsEnv = Object.keys(envs)
   .reduce((a, b) => {
     const checkEnv = envMap[envs[b].equals] || envs[b].equals;
     environments.some((env) => {
+      // go through all environment names to find the the current one
+      // and try to get the version as integer
       const version = parseInt(checkEnv.replace(env, ""), 10);
       if (!isNaN(version)) {
         Object.keys(envs).forEach((equals) => {
+          // Go through all envs from compat-table and get int version
           const equalsVersion = parseInt(equals.replace(env, ""), 10);
+          // If the current version is smaller than the version that was mentioned
+          // in `equals` we can add an entry, as older versions should include features
+          // that newer ones have
           if (!isNaN(equalsVersion) && equalsVersion <= version) {
             if (!a[equals]) a[equals] = [];
             a[equals].push(b);

--- a/test/debug-fixtures/built-ins/stdout.txt
+++ b/test/debug-fixtures/built-ins/stdout.txt
@@ -39,19 +39,19 @@ Using polyfills:
   es6.set {"ie":10,"node":6}
   es6.weak-map {"ie":10,"node":6}
   es6.weak-set {"ie":10,"node":6}
-  es6.reflect.apply {"ie":10,"node":6}
-  es6.reflect.construct {"ie":10,"node":6}
-  es6.reflect.define-property {"ie":10,"node":6}
-  es6.reflect.delete-property {"ie":10,"node":6}
-  es6.reflect.get {"ie":10,"node":6}
-  es6.reflect.get-own-property-descriptor {"ie":10,"node":6}
-  es6.reflect.get-prototype-of {"ie":10,"node":6}
-  es6.reflect.has {"ie":10,"node":6}
-  es6.reflect.is-extensible {"ie":10,"node":6}
-  es6.reflect.own-keys {"ie":10,"node":6}
-  es6.reflect.prevent-extensions {"ie":10,"node":6}
-  es6.reflect.set {"ie":10,"node":6}
-  es6.reflect.set-prototype-of {"ie":10,"node":6}
+  es6.reflect.apply {"ie":10}
+  es6.reflect.construct {"ie":10}
+  es6.reflect.define-property {"ie":10}
+  es6.reflect.delete-property {"ie":10}
+  es6.reflect.get {"ie":10}
+  es6.reflect.get-own-property-descriptor {"ie":10}
+  es6.reflect.get-prototype-of {"ie":10}
+  es6.reflect.has {"ie":10}
+  es6.reflect.is-extensible {"ie":10}
+  es6.reflect.own-keys {"ie":10}
+  es6.reflect.prevent-extensions {"ie":10}
+  es6.reflect.set {"ie":10}
+  es6.reflect.set-prototype-of {"ie":10}
   es6.promise {"ie":10,"node":6}
   es6.symbol {"ie":10,"node":6}
   es6.object.assign {"ie":10}
@@ -65,7 +65,7 @@ Using polyfills:
   es6.string.starts-with {"ie":10}
   es6.string.ends-with {"ie":10}
   es6.string.includes {"ie":10}
-  es6.regexp.flags {"ie":10,"node":6}
+  es6.regexp.flags {"ie":10}
   es6.regexp.match {"ie":10}
   es6.regexp.replace {"ie":10}
   es6.regexp.split {"ie":10}
@@ -101,7 +101,7 @@ Using polyfills:
   es6.math.sinh {"ie":10}
   es6.math.tanh {"ie":10}
   es6.math.trunc {"ie":10}
-  es7.array.includes {"ie":10,"node":6}
+  es7.array.includes {"ie":10}
   es7.object.values {"ie":10,"node":6}
   es7.object.entries {"ie":10,"node":6}
   es7.object.get-own-property-descriptors {"ie":10,"node":6}

--- a/test/debug-fixtures/plugins-only/stdout.txt
+++ b/test/debug-fixtures/plugins-only/stdout.txt
@@ -13,6 +13,5 @@ Using plugins:
   transform-es2015-for-of {"firefox":52}
   transform-es2015-function-name {"firefox":52}
   transform-es2015-literals {"firefox":52}
-  transform-exponentiation-operator {"node":7.4}
   syntax-trailing-function-commas {"node":7.4}
 src/in.js -> lib/in.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,9 +1067,9 @@ commoner@^0.10.1:
     q "^1.1.2"
     recast "^0.11.17"
 
-compat-table@kangax/compat-table#291c758ac618fff6bf5bb2113a5aa046189f93e2:
+compat-table@kangax/compat-table#c38f039b8ea7fadf347d3e300fec3611645e31e9:
   version "0.0.0"
-  resolved "https://codeload.github.com/kangax/compat-table/tar.gz/291c758ac618fff6bf5bb2113a5aa046189f93e2"
+  resolved "https://codeload.github.com/kangax/compat-table/tar.gz/c38f039b8ea7fadf347d3e300fec3611645e31e9"
   dependencies:
     babel-core latest
     babel-polyfill latest


### PR DESCRIPTION
This fixes issues, that some data from compat-table was not correctly imported.

The main issue is that compat-table sets an equals for `node7`

`node7 equals chrome54` because node7 uses v8 5.4
but the features might be already available since an earlier version of v8
For example exponentiation operator is available since v8 5.2 (in compat-table `chrome52`)
Though without this patch we don't have an entry in the inverse-equals-map, we only have chrom54->node7.

This corrects the behaviour and adds all older versions of an env also to the map.

Fixes #45 
Fixes #86