### PR TITLE
Increase mocha timout to 10s.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fix": "eslint . --fix",
     "ci": "npm run test",
     "changelog": "git log `git describe --tags --abbrev=0`..HEAD --pretty=format:' * %s (%an)' | grep -v 'Merge pull request'",
-    "test": "npm run build && mocha ./test --compilers js:babel-register -t 5000"
+    "test": "npm run build && mocha ./test --compilers js:babel-register -t 10000"
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "^6.3.13",


### PR DESCRIPTION
<img width="986" alt="screen shot 2017-03-10 at 14 20 23" src="https://cloud.githubusercontent.com/assets/1521229/23795172/bbff48d0-059c-11e7-8f1d-cfcd93117eaa.png">
sometimes appears with node 0.12 and 0.10.
Increasing timeout to 10s might help.