### PR TITLE
npmignore: Add related to build data and codecov.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,6 @@ node_modules
 scripts
 .eslintignore
 .travis.yml
+codecov.yml
+data/*.js
 yarn.lock


### PR DESCRIPTION
Seems like we don't need to publish js files from `data`. It's required only for `build-data` script which in `.npmignore` too.