### PR TITLE
Run yarn as pre-commit hook if package.json was changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     ],
     "package.json": [
       "node ./scripts/yarn-install.js",
-      "git add"
+      "git add yarn.lock"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "npm run build && npm run test-only",
     "test-ci": "nyc npm run test",
     "test-only": "mocha ./test --compilers js:babel-register -t 10000"
-    
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "7.0.0-alpha.1",
@@ -120,6 +119,10 @@
     ],
     "test/*.js": [
       "prettier --trailing-comma all --write",
+      "git add"
+    ],
+    "package.json": [
+      "node ./scripts/yarn-install.js",
       "git add"
     ]
   }

--- a/scripts/yarn-install.js
+++ b/scripts/yarn-install.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { exec } = require("child_process");
+const exec = require("child_process").exec;
 
 const runIfYarn = fn => {
   exec("yarn -V", error => {

--- a/scripts/yarn-install.js
+++ b/scripts/yarn-install.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const { exec } = require("child_process");
+
+// function to check if yarn is installed globally
+const runIfYarn = fn => {
+  exec("yarn -V", error => {
+    if (error === null) fn();
+  });
+};
+
+const yarn = () => {
+  console.log("`package.json` was changed. Running yarn...🐈");
+  exec("yarn");
+};
+
+runIfYarn(yarn);

--- a/scripts/yarn-install.js
+++ b/scripts/yarn-install.js
@@ -2,16 +2,12 @@
 
 const { exec } = require("child_process");
 
-// function to check if yarn is installed globally
 const runIfYarn = fn => {
   exec("yarn -V", error => {
     if (error === null) fn();
   });
 };
-
-const yarn = () => {
+runIfYarn(() => {
   console.log("`package.json` was changed. Running yarn...🐈");
   exec("yarn");
-};
-
-runIfYarn(yarn);
+});


### PR DESCRIPTION
Looks like not only me is tired of adding yarn.lock every time when some dependencies were changed. I was thinking about it and have an idea to run `yarn` as a pre-commit hook like we are doing for prettier. To run it only when `package.json` was added to commit. (thanks for awesome feature by @okonet).

What do you think?