### PR TITLE
Add check for ArrayBuffer[Symbol.species]

### DIFF
--- a/data/built-in-features.js
+++ b/data/built-in-features.js
@@ -25,11 +25,11 @@ const typedArrayMethods = [
   "typed arrays / %TypedArray%.prototype.values",
   "typed arrays / %TypedArray%.prototype.entries",
   "typed arrays / %TypedArray%.prototype[Symbol.iterator]",
-  "typed arrays / %TypedArray%[Symbol.species]"
+  "typed arrays / %TypedArray%[Symbol.species]",
 ];
 
 const es2015 = {
-  // "es6.typed/array-buffer": "typed arrays / ",
+  "es6.typed.array-buffer": "typed arrays / ArrayBuffer[Symbol.species]",
   "es6.typed.data-view": "typed arrays / DataView",
   "es6.typed.int8-array": {
     features: ["typed arrays / Int8Array"].concat(typedArrayMethods)

--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -1,4 +1,14 @@
 {
+  "es6.typed.array-buffer": {
+    "chrome": 51,
+    "edge": 13,
+    "firefox": 48,
+    "safari": 10,
+    "node": 6.5,
+    "ios": 10,
+    "opera": 38,
+    "electron": 1.2
+  },
   "es6.typed.data-view": {
     "chrome": 5,
     "opera": 12,

--- a/test/debug-fixtures/builtins/stdout.txt
+++ b/test/debug-fixtures/builtins/stdout.txt
@@ -35,6 +35,7 @@ Using plugins:
   syntax-trailing-function-commas {"chrome":54,"ie":10,"node":6}
 
 Using polyfills:
+  es6.typed.array-buffer {"ie":10,"node":6}
   es6.typed.int8-array {"ie":10,"node":6}
   es6.typed.uint8-array {"ie":10,"node":6}
   es6.typed.uint8-clamped-array {"ie":10,"node":6}

--- a/test/debug-fixtures/electron/stdout.txt
+++ b/test/debug-fixtures/electron/stdout.txt
@@ -22,6 +22,7 @@ Using plugins:
   syntax-trailing-function-commas {"electron":0.36}
 
 Using polyfills:
+  es6.typed.array-buffer {"electron":0.36}
   es6.typed.int8-array {"electron":0.36}
   es6.typed.uint8-array {"electron":0.36}
   es6.typed.uint8-clamped-array {"electron":0.36}

--- a/test/debug-fixtures/specific-targets/stdout.txt
+++ b/test/debug-fixtures/specific-targets/stdout.txt
@@ -38,6 +38,7 @@ Using plugins:
   syntax-trailing-function-commas {"chrome":54,"edge":13,"firefox":49,"ie":10,"ios":9,"safari":7}
 
 Using polyfills:
+  es6.typed.array-buffer {"ie":10,"ios":9,"safari":7}
   es6.typed.int8-array {"ie":10,"ios":9,"safari":7}
   es6.typed.uint8-array {"ie":10,"ios":9,"safari":7}
   es6.typed.uint8-clamped-array {"ie":10,"ios":9,"safari":7}

--- a/test/fixtures/preset-options/exclude-regenerator/expected.js
+++ b/test/fixtures/preset-options/exclude-regenerator/expected.js
@@ -1,3 +1,4 @@
+import "core-js/modules/es6.typed.array-buffer";
 import "core-js/modules/es6.typed.data-view";
 import "core-js/modules/es6.typed.int8-array";
 import "core-js/modules/es6.typed.uint8-array";

--- a/test/fixtures/preset-options/ie-11-built-ins/expected.js
+++ b/test/fixtures/preset-options/ie-11-built-ins/expected.js
@@ -1,3 +1,4 @@
+import "core-js/modules/es6.typed.array-buffer";
 import "core-js/modules/es6.typed.int8-array";
 import "core-js/modules/es6.typed.uint8-array";
 import "core-js/modules/es6.typed.uint8-clamped-array";

--- a/test/fixtures/preset-options/use-builtins-all/expected.js
+++ b/test/fixtures/preset-options/use-builtins-all/expected.js
@@ -1,3 +1,4 @@
+import "core-js/modules/es6.typed.array-buffer";
 import "core-js/modules/es6.typed.data-view";
 import "core-js/modules/es6.typed.int8-array";
 import "core-js/modules/es6.typed.uint8-array";

--- a/test/fixtures/preset-options/use-builtins-chrome-48/expected.js
+++ b/test/fixtures/preset-options/use-builtins-chrome-48/expected.js
@@ -1,3 +1,4 @@
+import "core-js/modules/es6.typed.array-buffer";
 import "core-js/modules/es6.typed.int8-array";
 import "core-js/modules/es6.typed.uint8-array";
 import "core-js/modules/es6.typed.uint8-clamped-array";

--- a/test/fixtures/preset-options/use-builtins-chrome-49/expected.js
+++ b/test/fixtures/preset-options/use-builtins-chrome-49/expected.js
@@ -1,3 +1,4 @@
+import "core-js/modules/es6.typed.array-buffer";
 import "core-js/modules/es6.typed.int8-array";
 import "core-js/modules/es6.typed.uint8-array";
 import "core-js/modules/es6.typed.uint8-clamped-array";

--- a/test/fixtures/preset-options/use-builtins-ie-9/actual.js
+++ b/test/fixtures/preset-options/use-builtins-ie-9/actual.js
@@ -1,0 +1,1 @@
+import "babel-polyfill";

--- a/test/fixtures/preset-options/use-builtins-ie-9/expected.js
+++ b/test/fixtures/preset-options/use-builtins-ie-9/expected.js
@@ -1,4 +1,5 @@
 import "core-js/modules/es6.typed.array-buffer";
+import "core-js/modules/es6.typed.data-view";
 import "core-js/modules/es6.typed.int8-array";
 import "core-js/modules/es6.typed.uint8-array";
 import "core-js/modules/es6.typed.uint8-clamped-array";

--- a/test/fixtures/preset-options/use-builtins-ie-9/options.json
+++ b/test/fixtures/preset-options/use-builtins-ie-9/options.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    ["../../../../lib", {
+      "targets": {
+        "ie": 9
+      },
+      "modules": false,
+      "useBuiltIns": true,
+      "modules": false
+    }]
+  ]
+}


### PR DESCRIPTION
Not really a comprehensive solution re: ArrayBuffer (as reported in #232), but we should include the polyfill where Symbol.species test fails.