### PR TITLE
Support electron version in a string format.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,10 @@ export const getTargets = (targets = {}) => {
     targetOpts.node = getCurrentNodeVersion();
   }
 
+  if (typeof targetOpts.electron === "string") {
+    targetOpts.electron = parseFloat(targetOpts.electron);
+  }
+
   if (targetOpts.hasOwnProperty("uglify") && !targetOpts.uglify) {
     delete targetOpts.uglify;
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -18,6 +18,14 @@ describe("babel-preset-env", () => {
         node: parseFloat(process.versions.node)
       });
     });
+
+    it("transforms electron version to a number", function() {
+      assert.deepEqual(babelPresetEnv.getTargets({
+        electron: "1.2"
+      }), {
+        electron: 1.2
+      });
+    });
   });
 
   describe("getTargets + uglify", () => {


### PR DESCRIPTION
Actually, it's incorrect behaviour we have unless https://github.com/babel/babel-preset-env/pull/229 was merged, but seems like many people used it with strings. https://github.com/babel/babel-preset-env/pull/229#issuecomment-290946494

It wasn't breaking change. It was a bug fix.
But we are ok to accept string unless 2.0 merged
