### PR TITLE
Clarify note about loading polyfills only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ npm install babel-polyfill --save
 This option enables a new plugin that replaces the statement `import "babel-polyfill"` or `require("babel-polyfill")` with individual requires for `babel-polyfill` based on environment.
 
 > NOTE: Only use `require("babel-polyfill");` once in your whole app. One option is to create a single entry file that only contains the require statement.
+> If `babel-polyfill` is loaded more than once, it will throw an error because these global polyfills can collide and provoke issues that are hard to trace.
 
 **In**
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ npm install babel-polyfill --save
 
 This option enables a new plugin that replaces the statement `import "babel-polyfill"` or `require("babel-polyfill")` with individual requires for `babel-polyfill` based on environment.
 
-> NOTE: Only use `require("babel-polyfill");` once in your whole app. One option is to create a single entry file that only contains the require statement.
-> If `babel-polyfill` is loaded more than once, it will throw an error because these global polyfills can collide and provoke issues that are hard to trace.
+> NOTE: Only use `require("babel-polyfill");` once in your whole app.
+> Multiple imports or requires of `babel-polyfill` will throw an error since it can cause global collisions and other issues that are hard to trace.
+> We recommend creating a single entry file that only contains the `require` statement.
 
 **In**
 


### PR DESCRIPTION
Reading the note, I wasn't sure if it could cause errors or not, and I had to look around for a little while.
Now it will say explicitly that loading `babel-polyfill` more than once will throw an error.