### PR TITLE
Add failing test for for..of combined with Set object

### DIFF
--- a/test/fixtures/preset-options-add-used-built-ins/builtins-used-syntax-only/actual.js
+++ b/test/fixtures/preset-options-add-used-built-ins/builtins-used-syntax-only/actual.js
@@ -1,0 +1,3 @@
+for (const a of new Set([1, 2, 3])) {
+  console.log(a);
+}

--- a/test/fixtures/preset-options-add-used-built-ins/builtins-used-syntax-only/expected.js
+++ b/test/fixtures/preset-options-add-used-built-ins/builtins-used-syntax-only/expected.js
@@ -1,0 +1,26 @@
+import "babel-polyfill/lib/core-js/modules/es6.set";
+import "babel-polyfill/lib/core-js/modules/es6.symbol";
+var _iteratorNormalCompletion = true;
+var _didIteratorError = false;
+var _iteratorError = undefined;
+
+try {
+  for (var _iterator = new Set([1, 2, 3])[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+    var a = _step.value;
+
+    console.log(a);
+  }
+} catch (err) {
+  _didIteratorError = true;
+  _iteratorError = err;
+} finally {
+  try {
+    if (!_iteratorNormalCompletion && _iterator.return) {
+      _iterator.return();
+    }
+  } finally {
+    if (_didIteratorError) {
+      throw _iteratorError;
+    }
+  }
+}

--- a/test/fixtures/preset-options-add-used-built-ins/builtins-used-syntax-only/options.json
+++ b/test/fixtures/preset-options-add-used-built-ins/builtins-used-syntax-only/options.json
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    ["../../../../lib", {
+      "useBuiltIns": "usage",
+      "modules": false
+    }]
+  ]
+}


### PR DESCRIPTION
It looks to be including the `web.dom.iterable.js` polyfill set, which is not required in this instance as no DOM apis are being called.

I think it needs to include `es6.symbol` as that is not included in the `es6.set` polyfill if I've understood the core.js source code correctly.