### PR TITLE
Consider stderr for debug fixtures.

### DIFF
--- a/test/debug-fixtures.js
+++ b/test/debug-fixtures.js
@@ -28,7 +28,7 @@ const testOutputType = (type, stdTarg, opts) => {
 
   if (optsTarg) {
     const expectStdout = optsTarg.trim();
-    chai.expect(stdTarg).to.equal(expectStdout, "stdout didn't match");
+    chai.expect(stdTarg).to.equal(expectStdout, `${type} didn't match`);
   } else {
     const file = path.join(opts.testLoc, `${type}.txt`);
     console.log(`New test file created: ${file}`);
@@ -64,8 +64,8 @@ const buildTest = opts => {
     let stdout = "";
     let stderr = "";
 
-    spawn.stdout.on("data", chunk => (stdout += chunk));
-    spawn.stderr.on("data", chunk => (stderr += chunk));
+    spawn.stdout.on("data", chunk => stdout += chunk);
+    spawn.stderr.on("data", chunk => stderr += chunk);
 
     spawn.on("close", () => {
       let err;
@@ -93,9 +93,14 @@ describe("debug output", () => {
     };
 
     const stdoutLoc = path.join(testLoc, "stdout.txt");
+    const stderrLoc = path.join(testLoc, "stderr.txt");
 
     if (fs.existsSync(stdoutLoc)) {
       opts.stdout = helper.readFile(stdoutLoc);
+    }
+
+    if (fs.existsSync(stderrLoc)) {
+      opts.stderr = helper.readFile(stderrLoc);
     }
 
     const optionsLoc = path.join(testLoc, "options.json");

--- a/test/debug-fixtures.js
+++ b/test/debug-fixtures.js
@@ -37,12 +37,6 @@ const testOutputType = (type, stdTarg, opts) => {
 };
 
 const assertTest = (stdout, stderr, opts) => {
-  // stderr = stderr.trim();
-
-  // if (stderr) {
-  //   throw new Error("stderr:\n" + stderr);
-  // }
-
   testOutputType("stdout", stdout, opts);
   if (stderr) {
     testOutputType("stderr", stderr, opts);

--- a/test/debug-fixtures/usage-with-import/in/in.js
+++ b/test/debug-fixtures/usage-with-import/in/in.js
@@ -1,0 +1,1 @@
+import 'babel-polyfill';

--- a/test/debug-fixtures/usage-with-import/options.json
+++ b/test/debug-fixtures/usage-with-import/options.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    ["../../lib", {
+      "debug": true,
+      "targets": {
+        "chrome": 55
+      },
+      "useBuiltIns": "usage"
+    }]
+  ]
+}

--- a/test/debug-fixtures/usage-with-import/stderr.txt
+++ b/test/debug-fixtures/usage-with-import/stderr.txt
@@ -1,0 +1,2 @@
+When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
+  Please remove the `import 'babel-polyfill'` call or use `useBuiltIns: 'entry'` instead.

--- a/test/debug-fixtures/usage-with-import/stderr.txt
+++ b/test/debug-fixtures/usage-with-import/stderr.txt
@@ -1,2 +1,2 @@
-When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
+  When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
   Please remove the `import 'babel-polyfill'` call or use `useBuiltIns: 'entry'` instead.

--- a/test/debug-fixtures/usage-with-import/stdout.txt
+++ b/test/debug-fixtures/usage-with-import/stdout.txt
@@ -1,0 +1,19 @@
+babel-preset-env: `DEBUG` option
+
+Using targets:
+{
+  "chrome": "55"
+}
+
+Using modules transform: commonjs
+
+Using plugins:
+  syntax-trailing-function-commas { "chrome":"55" }
+
+Using polyfills with `usage` option:
+
+  When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
+  Please remove the `import 'babel-polyfill'` call or use `useBuiltIns: 'entry'` instead.
+
+[index.js] Based on your code and targets, none were added.
+src/in.js -> lib/in.js

--- a/test/debug-fixtures/usage-with-import/stdout.txt
+++ b/test/debug-fixtures/usage-with-import/stdout.txt
@@ -12,8 +12,5 @@ Using plugins:
 
 Using polyfills with `usage` option:
 
-  When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
-  Please remove the `import 'babel-polyfill'` call or use `useBuiltIns: 'entry'` instead.
-
-[index.js] Based on your code and targets, none were added.
+[src/in.js] Based on your code and targets, none were added.
 src/in.js -> lib/in.js


### PR DESCRIPTION
Currently, for debug fixtures, we are matching only data from `stdout`. This PR adds an ability to consider `stderr` too.
Also added 'usage' option with `import 'babel-polyfill'` case where we providing `console.warn` message.

I think, in the future, it might be more useful not only for warns but error message outputs also.