### PR TITLE
README: Add string type as valid node target value

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The [data](https://github.com/babel/babel-preset-env/blob/master/data/plugins.js
 
 ### `targets.node`
 
-`number | "current" | true`
+`number | string | "current" | true`
 
 If you want to compile against the current node version, you can specify `"node": true` or `"node": "current"`, which would be the same as `"node": parseFloat(process.versions.node)`.
 


### PR DESCRIPTION
Clarify `node` targets by adding string type.
https://github.com/babel/babel-preset-env/issues/336