### PR TITLE
add maintained node target Fixes #341

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ The [data](https://github.com/babel/babel-preset-env/blob/master/data/plugins.js
 
 ### `targets.node`
 
-`number | string | "current" | true`
+`number | string | "current" | "maintained" | true`
 
 If you want to compile against the current node version, you can specify `"node": true` or `"node": "current"`, which would be the same as `"node": parseFloat(process.versions.node)`.
+If you want to compile against the latest [maintained](https://github.com/nodejs/LTS) node version, you can specify: "node": "maintained".
 
 ### `targets.browsers`
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-plugin-transform-regenerator": "^6.22.0",
     "browserslist": "^2.1.2",
     "invariant": "^2.2.2",
+    "lodash.sortedindexby": "^4.6.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/src/targets-parser.js
+++ b/src/targets-parser.js
@@ -1,3 +1,4 @@
+import sortedIndexBy from "lodash.sortedindexby";
 import browserslist from "browserslist";
 import semver from "semver";
 import { semverify } from "./utils";
@@ -63,6 +64,19 @@ const outputDecimalWarning = (decimalTargets) => {
   console.log("");
 };
 
+const supportedNodeVersions = [
+  [new Date(2018, 4, 0), semverify("4")],
+  [new Date(2019, 4, 0), semverify("6")],
+  [new Date(2019, 12, 0), semverify("8")],
+  [new Date(2021, 4, 0), semverify("10")],
+  [Infinity, semverify("12")],
+];
+
+function getSupportedNode(date) {
+  const index = sortedIndexBy(supportedNodeVersions, [date], (v) => v[0]);
+  return supportedNodeVersions[index];
+}
+
 const targetParserMap = {
   __default: (target, value) => [target, semverify(value)],
 
@@ -72,7 +86,7 @@ const targetParserMap = {
       switch (value) {
         case true:
         case "current": return process.versions.node;
-        case "maintained": return semverify("4");
+        case "maintained": return getSupportedNode(new Date());
         default: return semverify(value);
       }
     })();

--- a/src/targets-parser.js
+++ b/src/targets-parser.js
@@ -68,9 +68,14 @@ const targetParserMap = {
 
   // Parse `node: true` and `node: "current"` to version
   node: (target, value) => {
-    const parsed = value === true || value === "current"
-      ? process.versions.node
-      : semverify(value);
+    const parsed = (() => {
+      switch (value) {
+        case true:
+        case "current": return process.versions.node;
+        case "maintained": return semverify("4");
+        default: return semverify(value);
+      }
+    })();
 
     return [target, parsed];
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,10 @@ lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash.sortedindexby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortedindexby/-/lodash.sortedindexby-4.6.0.tgz#46f198fbdfbcd09c6fd4c177d37cda3cc652d9f9"
+
 lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"


### PR DESCRIPTION
these flags suggest that users with babel-register should use 'current' and `babel src dist` should use 'maintained'