### PR TITLE
Bump compat-table for node8 support

### DIFF
--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -327,7 +327,6 @@
     "safari": "9",
     "node": "0.12",
     "ie": "11",
-    "android": "5",
     "ios": "9",
     "opera": "21",
     "electron": "0.2"
@@ -522,7 +521,6 @@
     "firefox": "28",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -543,7 +541,6 @@
     "firefox": "16",
     "safari": "9",
     "node": "0.12",
-    "android": "5",
     "ios": "9",
     "opera": "21",
     "electron": "0.2"
@@ -554,7 +551,6 @@
     "firefox": "32",
     "safari": "9",
     "node": "0.12",
-    "android": "5",
     "ios": "9",
     "opera": "21",
     "electron": "0.2"
@@ -575,7 +571,6 @@
     "firefox": "25",
     "safari": "9",
     "node": "0.12",
-    "android": "5",
     "ios": "9",
     "opera": "21",
     "electron": "0.2"
@@ -586,7 +581,6 @@
     "firefox": "31",
     "safari": "9",
     "node": "0.12",
-    "android": "5",
     "ios": "9",
     "opera": "21",
     "electron": "0.2"
@@ -597,7 +591,6 @@
     "firefox": "31",
     "safari": "9",
     "node": "0.12",
-    "android": "5",
     "ios": "9",
     "opera": "21",
     "electron": "0.2"
@@ -608,7 +601,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -619,7 +611,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -630,7 +621,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -641,7 +631,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -652,7 +641,6 @@
     "firefox": "31",
     "safari": "9",
     "node": "0.12",
-    "android": "5.1",
     "ios": "9",
     "opera": "25",
     "electron": "0.2"
@@ -663,7 +651,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -674,7 +661,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -685,7 +671,6 @@
     "firefox": "26",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -696,7 +681,6 @@
     "firefox": "27",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -707,7 +691,6 @@
     "firefox": "23",
     "safari": "7",
     "node": "0.12",
-    "android": "4.4",
     "ios": "7",
     "opera": "17",
     "electron": "0.2"
@@ -718,7 +701,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -729,7 +711,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -740,7 +721,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -751,7 +731,6 @@
     "firefox": "25",
     "safari": "9",
     "node": "0.12",
-    "android": "5.1",
     "ios": "9",
     "opera": "25",
     "electron": "0.2"
@@ -762,7 +741,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -773,7 +751,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -784,7 +761,6 @@
     "firefox": "25",
     "safari": "7.1",
     "node": "0.12",
-    "android": "5.1",
     "ios": "8",
     "opera": "25",
     "electron": "0.2"
@@ -834,6 +810,7 @@
     "edge": "15",
     "firefox": "48",
     "safari": "10",
+    "node": "8",
     "ios": "10",
     "opera": "44",
     "electron": "1.7"
@@ -843,6 +820,7 @@
     "edge": "15",
     "firefox": "48",
     "safari": "10",
+    "node": "8",
     "ios": "10",
     "opera": "44",
     "electron": "1.7"

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -175,7 +175,6 @@
     "firefox": "36",
     "safari": "9",
     "node": "0.12",
-    "android": "5.1",
     "ios": "9",
     "opera": "25",
     "electron": "0.2"
@@ -225,6 +224,7 @@
     "edge": "14",
     "firefox": "52",
     "safari": "10",
+    "node": "8",
     "ios": "10",
     "opera": "45",
     "electron": "1.7"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-register": "^6.23.0",
     "chai": "^3.5.0",
     "codecov": "^1.0.1",
-    "compat-table": "kangax/compat-table#1f0bb0913736fe8c4c11b139766c73b9cbedb9f2",
+    "compat-table": "kangax/compat-table#d88c80ea6dcbc7064112eb46bb020718107892f7",
     "eslint": "^3.17.1",
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-flowtype": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint": "^3.17.1",
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-flowtype": "^2.29.1",
-    "fs-extra": "^2.0.0",
+    "fs-extra": "~2.0.0",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,12 +989,6 @@ binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
-bl@~0.9.3:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-0.9.5.tgz#c06b797af085ea00bc527afc8efcf11de2232054"
-  dependencies:
-    readable-stream "~1.0.26"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -1179,17 +1173,25 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-closurecompiler-externs@*:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/closurecompiler-externs/-/closurecompiler-externs-1.0.4.tgz#48ea3200b70a53d4681556c4a1706dec242537a3"
+clone-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
-closurecompiler@latest:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/closurecompiler/-/closurecompiler-1.6.1.tgz#2adde92bc8e89ff6871a11cf01a59e12650a030f"
+clone-stats@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
+
+clone@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
+cloneable-readable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.0.0.tgz#a6290d413f217a61232f95e458ff38418cfb0117"
   dependencies:
-    bl "~0.9.3"
-    closurecompiler-externs "*"
-    tar "~2.2.1"
+    inherits "^2.0.1"
+    process-nextick-args "^1.0.6"
+    through2 "^2.0.1"
 
 co@^4.6.0:
   version "4.6.0"
@@ -1238,9 +1240,9 @@ commoner@^0.10.1:
     q "^1.1.2"
     recast "^0.11.17"
 
-compat-table@kangax/compat-table#1f0bb0913736fe8c4c11b139766c73b9cbedb9f2:
+compat-table@kangax/compat-table#d88c80ea6dcbc7064112eb46bb020718107892f7:
   version "0.0.0"
-  resolved "https://codeload.github.com/kangax/compat-table/tar.gz/1f0bb0913736fe8c4c11b139766c73b9cbedb9f2"
+  resolved "https://codeload.github.com/kangax/compat-table/tar.gz/d88c80ea6dcbc7064112eb46bb020718107892f7"
   dependencies:
     babel-core latest
     babel-polyfill latest
@@ -1250,7 +1252,6 @@ compat-table@kangax/compat-table#1f0bb0913736fe8c4c11b139766c73b9cbedb9f2:
     babel-preset-stage-0 latest
     chalk "^1.1.3"
     cheerio "^0.20.0"
-    closurecompiler latest
     core-js latest
     es5-shim latest
     es6-shim latest
@@ -1259,6 +1260,7 @@ compat-table@kangax/compat-table#1f0bb0913736fe8c4c11b139766c73b9cbedb9f2:
     esdown latest
     espree latest
     esprima latest
+    google-closure-compiler-js "^20170521.0.0"
     jshint latest
     jstransform latest
     lodash.pickby "^4.6.0"
@@ -1475,7 +1477,7 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-to-chromium@^1.3.11:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.11, electron-to-chromium@^1.3.9:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.11.tgz#744761df1d67b492b322ce9aa0aba5393260eb61"
 
@@ -1995,6 +1997,14 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+google-closure-compiler-js@^20170521.0.0:
+  version "20170521.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20170521.0.0.tgz#9ac5fd6818aa500333a199ed0a9d0449e52120c9"
+  dependencies:
+    minimist "^1.2.0"
+    vinyl "^2.0.1"
+    webpack-core "^0.6.8"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
@@ -2967,7 +2977,7 @@ private@^0.1.6, private@~0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.6.tgz#55c6a976d0f9bafb9924851350fe47b9b5fbb7c1"
 
-process-nextick-args@~1.0.6:
+process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
@@ -3031,7 +3041,7 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -3042,15 +3052,6 @@ readable-stream@1.1:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
-
-readable-stream@~1.0.26:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@~2.1.4:
   version "2.1.5"
@@ -3137,6 +3138,10 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
+remove-trailing-separator@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
+
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
@@ -3150,6 +3155,10 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request@>=2.42.0, request@^2.55.0, request@^2.79.0:
   version "2.79.0"
@@ -3314,6 +3323,10 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+source-list-map@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
+
 source-map-support@^0.4.2:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
@@ -3332,7 +3345,7 @@ source-map@0.1.32:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.4.2, source-map@^0.4.4:
+source-map@^0.4.2, source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -3559,6 +3572,13 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+through2@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -3686,9 +3706,27 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
+vinyl@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.1.0.tgz#021f9c2cf951d6b939943c89eb5ee5add4fd924c"
+  dependencies:
+    clone "^2.1.1"
+    clone-buffer "^1.0.0"
+    clone-stats "^1.0.0"
+    cloneable-readable "^1.0.0"
+    remove-trailing-separator "^1.0.1"
+    replace-ext "^1.0.0"
+
 webidl-conversions@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-2.0.1.tgz#3bf8258f7d318c7443c36f2e169402a1a6703506"
+
+webpack-core@^0.6.8:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
+  dependencies:
+    source-list-map "~0.1.7"
+    source-map "~0.4.1"
 
 whatwg-url-compat@~0.6.5:
   version "0.6.5"
@@ -3757,7 +3795,7 @@ write@^0.2.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Fixes #361.

The android > 4.4 releases were removed in compat-table since it's just Chrome. (ref https://github.com/kangax/compat-table/pull/1104)