### PR TITLE
Handle `chromeandroid` browserslist value. Fixes #366.

### DIFF
--- a/src/targets-parser.js
+++ b/src/targets-parser.js
@@ -5,6 +5,7 @@ import { semverify } from "./utils";
 const browserNameMap = {
   android: "android",
   chrome: "chrome",
+  and_chr: "chrome",
   edge: "edge",
   firefox: "firefox",
   ie: "ie",

--- a/test/fixtures/preset-options/use-builtins-chromeandroid/actual.js
+++ b/test/fixtures/preset-options/use-builtins-chromeandroid/actual.js
@@ -1,0 +1,2 @@
+import "babel-polyfill";
+1 ** 2;

--- a/test/fixtures/preset-options/use-builtins-chromeandroid/expected.js
+++ b/test/fixtures/preset-options/use-builtins-chromeandroid/expected.js
@@ -1,0 +1,5 @@
+import "core-js/modules/web.timers";
+import "core-js/modules/web.immediate";
+import "core-js/modules/web.dom.iterable";
+
+1 ** 2;

--- a/test/fixtures/preset-options/use-builtins-chromeandroid/options.json
+++ b/test/fixtures/preset-options/use-builtins-chromeandroid/options.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    ["../../../../lib", {
+      "targets": {
+        "browsers": "chromeandroid 59"
+      },
+      "modules": false,
+      "useBuiltIns": true
+    }]
+  ]
+}


### PR DESCRIPTION
Browserslist [supports chromeandroid](http://browserl.ist/?q=last+5+chromeandroid+version) value. I've just added mapping `and_chr` to `chrome`.
I don't think we need to specify, handle and log it as a separate target from the chrome. Rather for browserslist conformity.