### PR TITLE
Normalize module format of plugins/built-ins data

### DIFF
--- a/data/plugin-features.js
+++ b/data/plugin-features.js
@@ -1,5 +1,4 @@
-module.exports = {
-  // es2015
+const es2015 = {
   "check-es2015-constants": {
     features: [
       "const",
@@ -107,16 +106,18 @@ module.exports = {
     features: [
       "generators",
     ],
-  },
+  }
+};
 
-  // es2016
+const es2016 = {
   "transform-exponentiation-operator": {
     features: [
       "exponentiation (**) operator",
     ],
-  },
+  }
+};
 
-  // es2017
+const es2017 = {
   "transform-async-to-generator": {
     features: [
       "async functions",
@@ -128,3 +129,5 @@ module.exports = {
     ],
   }
 };
+
+module.exports = Object.assign({}, es2015, es2016, es2017);

--- a/src/normalize-options.js
+++ b/src/normalize-options.js
@@ -2,10 +2,10 @@ import invariant from "invariant";
 import builtInsList from "../data/built-ins.json";
 import { defaultWebIncludes } from "./default-includes";
 import moduleTransformations from "./module-transformations";
-import pluginFeatures from "../data/plugin-features";
+import pluginsList from "../data/plugins.json";
 
 const validIncludesAndExcludes = [
-  ...Object.keys(pluginFeatures),
+  ...Object.keys(pluginsList),
   ...Object.keys(moduleTransformations).map((m) => moduleTransformations[m]),
   ...Object.keys(builtInsList),
   ...defaultWebIncludes,


### PR DESCRIPTION
Slight refactor of `data/plugin-features.js` that makes it match the same format of [`data/built-in-features.js` where the data is organized by ECMAScript year](https://github.com/babel/babel-preset-env/blob/db25efd99a1d58a8eb08abcf0b495166000872a9/data/built-in-features.js#L181).

Resolves https://github.com/babel/babel-preset-env/issues/373 by allowing package authors to import `babel-preset-env/data/plugin-features.js` and `babel-preset-env/data/plugin-features.js` and assemble the desired exclusions/inclusions (corresponding to a language target) on their own. There's no need for a first-class interface as long as the format of `data/plugin-features.js` and `data/built-in-features.js` is preserved (whereby a clean userland implementation is possible).

Note: this PR does not alter the output produced by the `build-data` script in any way. The output is byte-for-byte exactly as what is currently committed to master.