### PR TITLE
Fixed "node: current" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The [data](https://github.com/babel/babel-preset-env/blob/master/data/plugins.js
 
 `number | string | "current" | true`
 
-If you want to compile against the current node version, you can specify `"node": true` or `"node": "current"`, which would be the same as `"node": parseFloat(process.versions.node)`.
+If you want to compile against the current node version, you can specify `"node": true` or `"node": "current"`, which would be the same as `"node": process.versions.node`.
 
 ### `targets.browsers`
 


### PR DESCRIPTION
`parseFloat` is not applied anymore to "node: current" logic:
The parseFloat was wrong, as `parseFloat('6.3.2')` will parse as 6.3, but `parseFloat('6.10.2')` will output 6.1 that is not correct.

Ref: https://github.com/babel/babel-preset-env/blob/master/src/targets-parser.js#L73