### PR TITLE
Add Number.parseFloat/Number.parseInt mappings

### DIFF
--- a/data/built-in-features.js
+++ b/data/built-in-features.js
@@ -155,6 +155,8 @@ const es2015 = {
   "es6.number.epsilon": "Number properties / Number.EPSILON",
   "es6.number.min-safe-integer": "Number properties / Number.MIN_SAFE_INTEGER",
   "es6.number.max-safe-integer": "Number properties / Number.MAX_SAFE_INTEGER",
+  "es6.number.parse-float": "Number properties / Number.parseFloat",
+  "es6.number.parse-int": "Number properties / Number.parseInt",
 
   "es6.math.acosh": "Math methods / Math.acosh",
   "es6.math.asinh": "Math methods / Math.asinh",

--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -595,6 +595,26 @@
     "opera": "21",
     "electron": "0.2"
   },
+  "es6.number.parse-float": {
+    "chrome": "34",
+    "edge": "12",
+    "firefox": "25",
+    "safari": "9",
+    "node": "0.12",
+    "ios": "9",
+    "opera": "21",
+    "electron": "0.2"
+  },
+  "es6.number.parse-int": {
+    "chrome": "34",
+    "edge": "12",
+    "firefox": "25",
+    "safari": "9",
+    "node": "0.12",
+    "ios": "9",
+    "opera": "21",
+    "electron": "0.2"
+  },
   "es6.math.acosh": {
     "chrome": "38",
     "edge": "12",

--- a/test/debug-fixtures/android/stdout.txt
+++ b/test/debug-fixtures/android/stdout.txt
@@ -95,6 +95,8 @@ Using polyfills with `entry` option:
   es6.number.epsilon { "android":"4" }
   es6.number.min-safe-integer { "android":"4" }
   es6.number.max-safe-integer { "android":"4" }
+  es6.number.parse-float { "android":"4" }
+  es6.number.parse-int { "android":"4" }
   es6.math.acosh { "android":"4" }
   es6.math.asinh { "android":"4" }
   es6.math.atanh { "android":"4" }

--- a/test/debug-fixtures/builtins/stdout.txt
+++ b/test/debug-fixtures/builtins/stdout.txt
@@ -97,6 +97,8 @@ Using polyfills with `entry` option:
   es6.number.epsilon { "ie":"10" }
   es6.number.min-safe-integer { "ie":"10" }
   es6.number.max-safe-integer { "ie":"10" }
+  es6.number.parse-float { "ie":"10" }
+  es6.number.parse-int { "ie":"10" }
   es6.math.acosh { "ie":"10" }
   es6.math.asinh { "ie":"10" }
   es6.math.atanh { "ie":"10" }

--- a/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/test/debug-fixtures/shippedProposals/stdout.txt
@@ -98,6 +98,8 @@ Using polyfills with `entry` option:
   es6.number.epsilon {}
   es6.number.min-safe-integer {}
   es6.number.max-safe-integer {}
+  es6.number.parse-float {}
+  es6.number.parse-int {}
   es6.math.acosh {}
   es6.math.asinh {}
   es6.math.atanh {}

--- a/test/debug-fixtures/specific-targets/stdout.txt
+++ b/test/debug-fixtures/specific-targets/stdout.txt
@@ -100,6 +100,8 @@ Using polyfills with `entry` option:
   es6.number.epsilon { "ie":"10", "safari":"7" }
   es6.number.min-safe-integer { "ie":"10", "safari":"7" }
   es6.number.max-safe-integer { "ie":"10", "safari":"7" }
+  es6.number.parse-float { "ie":"10", "safari":"7" }
+  es6.number.parse-int { "ie":"10", "safari":"7" }
   es6.math.acosh { "ie":"10", "safari":"7" }
   es6.math.asinh { "ie":"10", "safari":"7" }
   es6.math.atanh { "ie":"10", "safari":"7" }

--- a/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/test/debug-fixtures/versions-decimals/stdout.txt
@@ -107,6 +107,8 @@ Using polyfills with `entry` option:
   es6.number.epsilon { "ie":"10" }
   es6.number.min-safe-integer { "ie":"10" }
   es6.number.max-safe-integer { "ie":"10" }
+  es6.number.parse-float { "ie":"10" }
+  es6.number.parse-int { "ie":"10" }
   es6.math.acosh { "ie":"10" }
   es6.math.asinh { "ie":"10" }
   es6.math.atanh { "ie":"10" }

--- a/test/debug-fixtures/versions-strings/stdout.txt
+++ b/test/debug-fixtures/versions-strings/stdout.txt
@@ -97,6 +97,8 @@ Using polyfills with `entry` option:
   es6.number.epsilon { "ie":"10" }
   es6.number.min-safe-integer { "ie":"10" }
   es6.number.max-safe-integer { "ie":"10" }
+  es6.number.parse-float { "ie":"10" }
+  es6.number.parse-int { "ie":"10" }
   es6.math.acosh { "ie":"10" }
   es6.math.asinh { "ie":"10" }
   es6.math.atanh { "ie":"10" }

--- a/test/fixtures/preset-options/exclude-regenerator/expected.js
+++ b/test/fixtures/preset-options/exclude-regenerator/expected.js
@@ -58,6 +58,8 @@ import "babel-polyfill/lib/core-js/modules/es6.number.is-nan";
 import "babel-polyfill/lib/core-js/modules/es6.number.epsilon";
 import "babel-polyfill/lib/core-js/modules/es6.number.min-safe-integer";
 import "babel-polyfill/lib/core-js/modules/es6.number.max-safe-integer";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-float";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-int";
 import "babel-polyfill/lib/core-js/modules/es6.math.acosh";
 import "babel-polyfill/lib/core-js/modules/es6.math.asinh";
 import "babel-polyfill/lib/core-js/modules/es6.math.atanh";

--- a/test/fixtures/preset-options/ie-11-built-ins/expected.js
+++ b/test/fixtures/preset-options/ie-11-built-ins/expected.js
@@ -56,6 +56,8 @@ import "babel-polyfill/lib/core-js/modules/es6.number.is-nan";
 import "babel-polyfill/lib/core-js/modules/es6.number.epsilon";
 import "babel-polyfill/lib/core-js/modules/es6.number.min-safe-integer";
 import "babel-polyfill/lib/core-js/modules/es6.number.max-safe-integer";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-float";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-int";
 import "babel-polyfill/lib/core-js/modules/es6.math.acosh";
 import "babel-polyfill/lib/core-js/modules/es6.math.asinh";
 import "babel-polyfill/lib/core-js/modules/es6.math.atanh";

--- a/test/fixtures/preset-options/use-builtins-all/expected.js
+++ b/test/fixtures/preset-options/use-builtins-all/expected.js
@@ -58,6 +58,8 @@ import "babel-polyfill/lib/core-js/modules/es6.number.is-nan";
 import "babel-polyfill/lib/core-js/modules/es6.number.epsilon";
 import "babel-polyfill/lib/core-js/modules/es6.number.min-safe-integer";
 import "babel-polyfill/lib/core-js/modules/es6.number.max-safe-integer";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-float";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-int";
 import "babel-polyfill/lib/core-js/modules/es6.math.acosh";
 import "babel-polyfill/lib/core-js/modules/es6.math.asinh";
 import "babel-polyfill/lib/core-js/modules/es6.math.atanh";

--- a/test/fixtures/preset-options/use-builtins-ie-9/expected.js
+++ b/test/fixtures/preset-options/use-builtins-ie-9/expected.js
@@ -58,6 +58,8 @@ import "babel-polyfill/lib/core-js/modules/es6.number.is-nan";
 import "babel-polyfill/lib/core-js/modules/es6.number.epsilon";
 import "babel-polyfill/lib/core-js/modules/es6.number.min-safe-integer";
 import "babel-polyfill/lib/core-js/modules/es6.number.max-safe-integer";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-float";
+import "babel-polyfill/lib/core-js/modules/es6.number.parse-int";
 import "babel-polyfill/lib/core-js/modules/es6.math.acosh";
 import "babel-polyfill/lib/core-js/modules/es6.math.asinh";
 import "babel-polyfill/lib/core-js/modules/es6.math.atanh";

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,6 +249,14 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-core@7.0.0-alpha.16:
   version "7.0.0-alpha.16"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-alpha.16.tgz#a62c55f123b5e80f6e368006586749573e483617"
@@ -711,11 +719,11 @@ babel-plugin-check-es2015-constants@^6.22.0:
     babel-runtime "^6.22.0"
 
 babel-plugin-istanbul@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz#18dde84bf3ce329fddf3f4103fae921456d8e587"
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
     find-up "^2.1.0"
-    istanbul-lib-instrument "^1.7.2"
+    istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
 babel-plugin-syntax-async-functions@7.0.0-alpha.16:
@@ -1658,7 +1666,7 @@ babel-traverse@7.0.0-beta.2:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -1671,6 +1679,20 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
+
+babel-traverse@^6.23.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
 
 babel-types@7.0.0-alpha.16:
   version "7.0.0-alpha.16"
@@ -1688,7 +1710,7 @@ babel-types@7.0.0-beta.2:
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -1697,7 +1719,7 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.26.0:
+babel-types@^6.23.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1714,9 +1736,13 @@ babylon@7.0.0-beta.25:
   version "7.0.0-beta.25"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.25.tgz#5fff5062b7082203b1bc5cab488e154cfee0202a"
 
-babylon@^6.11.0, babylon@^6.15.0, babylon@^6.17.0:
+babylon@^6.11.0, babylon@^6.15.0:
   version "6.17.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
+
+babylon@^6.17.0, babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 babylon@^6.17.4:
   version "6.17.4"
@@ -1775,14 +1801,7 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
-browserslist@^2.1.2:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.1.4.tgz#cc526af4a1312b7d2e05653e56d0c8ab70c0e053"
-  dependencies:
-    caniuse-lite "^1.0.30000670"
-    electron-to-chromium "^1.3.11"
-
-browserslist@^2.4.0:
+browserslist@^2.1.2, browserslist@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.4.0.tgz#693ee93d01e66468a6348da5498e011f578f87f8"
   dependencies:
@@ -1826,10 +1845,6 @@ camelcase@^3.0.0:
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-
-caniuse-lite@^1.0.30000670:
-  version "1.0.30000676"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000676.tgz#1e962123f48073f0c51c4ea0651dd64d25786498"
 
 caniuse-lite@^1.0.30000718:
   version "1.0.30000733"
@@ -2061,7 +2076,6 @@ compat-table@kangax/compat-table#b8477cc0f6d65c000c46213e654d19f350de9fa8:
     babel-preset-stage-0 latest
     chalk "^1.1.3"
     cheerio "^0.20.0"
-    closurecompiler latest
     core-js latest
     es5-shim latest
     es6-shim latest
@@ -2070,6 +2084,7 @@ compat-table@kangax/compat-table#b8477cc0f6d65c000c46213e654d19f350de9fa8:
     esdown latest
     espree latest
     esprima latest
+    google-closure-compiler-js "^20170521.0.0"
     jshint latest
     jstransform latest
     lodash.pickby "^4.6.0"
@@ -2204,6 +2219,12 @@ debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
   dependencies:
     ms "0.7.3"
 
+debug@^2.6.8:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.1.tgz#0564c612b521dc92d9f2988f0549e34f9c98db64"
@@ -2322,10 +2343,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-electron-to-chromium@^1.3.11:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz#1b3a5eace6e087bb5e257a100b0cbfe81b2891fc"
 
 electron-to-chromium@^1.3.18:
   version "1.3.21"
@@ -2896,6 +2913,10 @@ globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -3004,6 +3025,12 @@ home-or-tmp@^2.0.0:
 home-or-tmp@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
+
+homedir-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.4.2"
@@ -3290,7 +3317,7 @@ istanbul-lib-hook@^1.0.7:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.7.4:
+istanbul-lib-instrument@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz#e9fd920e4767f3d19edc765e2d6b3f5ccbd0eea8"
   dependencies:
@@ -3299,6 +3326,18 @@ istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.7.4:
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
     babylon "^6.17.4"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
+istanbul-lib-instrument@^1.7.5:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz#66f6c9421cc9ec4704f76f2db084ba9078a2b532"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
     istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
@@ -3336,6 +3375,10 @@ jodid25519@^1.0.0:
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.4.3, js-yaml@^3.5.1:
   version "3.8.3"
@@ -4050,6 +4093,10 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
 parse5@^1.5.1:
   version "1.5.1"
@@ -5044,10 +5091,6 @@ urlgrey@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
-user-home@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -5063,10 +5106,10 @@ uuid@^3.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
 v8flags@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.0.tgz#4be9604488e0c4123645def705b1848d16b8e01f"
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.1.tgz#dce8fc379c17d9f2c9e9ed78d89ce00052b1b76b"
   dependencies:
-    user-home "^1.1.1"
+    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Fixes https://github.com/babel/babel-preset-env/issues/385.

Before shipping, we need to resolve mappings in [babel-polyfill](https://github.com/babel/babel/tree/7.0/packages/babel-polyfill/src/core-js/modules).