### PR TITLE
Add 'lib/types.js' to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 coverage
 src
 test
+lib/types.js
 node_modules
 scripts
 .eslintignore


### PR DESCRIPTION
Add `lib/types.js` to .npmignore to prevent its erasion.