### PR TITLE
Docs: fix claim about node versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you are targeting IE 8 and Chrome 55 it will include all plugins required by 
 
 ### Support a target option `"node": "current"` to compile for the currently running node version.
 
-For example, if you are building on Node 4, arrow functions won't be converted, but they will if you build on Node 0.12.
+For example, if you are building on Node 6, arrow functions won't be converted, but they will if you build on Node 0.12.
 
 ### Support a `browsers` option like autoprefixer
 


### PR DESCRIPTION
Arrow functions [will in fact](https://github.com/babel/babel-preset-env/blob/be7a61c368149cd7e9d4202ecec6f71c56f2eb77/data/plugins.json#L17) be transformed when building for Node 4.