### PR TITLE
Bump compat-table

### DIFF
--- a/data/built-ins.json
+++ b/data/built-ins.json
@@ -691,6 +691,7 @@
     "firefox": "23",
     "safari": "7",
     "node": "0.12",
+    "android": "4.4",
     "ios": "7",
     "opera": "17",
     "electron": "0.2"

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -62,7 +62,6 @@
   },
   "transform-es2015-destructuring": {
     "chrome": "51",
-    "edge": "15",
     "firefox": "53",
     "safari": "10",
     "node": "6.5",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "babel-register": "7.0.0-alpha.16",
     "chai": "^4.0.2",
     "codecov": "^2.2.0",
-    "compat-table": "kangax/compat-table#d88c80ea6dcbc7064112eb46bb020718107892f7",
+    "compat-table": "kangax/compat-table#b8477cc0f6d65c000c46213e654d19f350de9fa8",
     "eslint": "^3.17.1",
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-flowtype": "^2.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,9 +1957,9 @@ commoner@^0.10.1:
     q "^1.1.2"
     recast "^0.11.17"
 
-compat-table@kangax/compat-table#d88c80ea6dcbc7064112eb46bb020718107892f7:
+compat-table@kangax/compat-table#b8477cc0f6d65c000c46213e654d19f350de9fa8:
   version "0.0.0"
-  resolved "https://codeload.github.com/kangax/compat-table/tar.gz/d88c80ea6dcbc7064112eb46bb020718107892f7"
+  resolved "https://codeload.github.com/kangax/compat-table/tar.gz/b8477cc0f6d65c000c46213e654d19f350de9fa8"
   dependencies:
     babel-core latest
     babel-polyfill latest


### PR DESCRIPTION
Notable changes:

* `transform-destructuring` will now be enabled on Edge 15 due to a new test for destructuring defaults w/ arrow func (https://github.com/kangax/compat-table/pull/1161)

* Android 4.4 results were re-added (https://github.com/kangax/compat-table/pull/1158)

* Safari TP updates, useful for https://github.com/babel/babel-preset-env/pull/402 (https://github.com/kangax/compat-table/pull/1174)

* Number.parseFloat and Number.parseInt mappings (https://github.com/kangax/compat-table/pull/1151)