### PR TITLE
Fix table of contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ For convenience, you can use `"node": "current"` to only include the necessary p
 - [Usage](#usage)
 - [Options](#options)
 - [Examples](#examples)
-- [Caveats](#caveats)
-- [Other Cool Projects](#other-cool-projects)
+- [Issues](#issues)
 
 ## How it Works
 


### PR DESCRIPTION
Caveat was renamed to Issues. 'Other Cool Projects' was removed.
Both happened in e4b89a1.