### PR TITLE
Update browserslist to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
     "babel-plugin-transform-exponentiation-operator": "^6.22.0",
     "babel-plugin-transform-regenerator": "^6.22.0",
-    "browserslist": "^2.1.2",
+    "browserslist": "^3.2.6",
     "invariant": "^2.2.2",
     "semver": "^5.3.0"
   },


### PR DESCRIPTION
Parcel users are getting "Unknown version 65 of chrome" with the old version since we depend on the latest browserslist already so there are 2 copies installed. See issue https://github.com/parcel-bundler/parcel/issues/1036